### PR TITLE
docs: clarify Button.Start is host-app available

### DIFF
--- a/Runtime/RoomScanInputHandler.cs
+++ b/Runtime/RoomScanInputHandler.cs
@@ -51,7 +51,11 @@ namespace Genesis.RoomScan
         [SerializeField, Tooltip("Controller button → action mappings. Editable at runtime.")]
         private List<ScanInputBinding> bindings = new()
         {
-            // Left thumbstick click — Quest OS intercepts Button.Start for system menu
+            // Left thumbstick click. NOTE: OVRInput.Button.Start (left ≡) is
+            // NOT reserved by Horizon OS — only the right Meta/Oculus logo
+            // button is. We use thumbstick-click here instead so host apps
+            // remain free to wire Button.Start to their own pause menu, which
+            // is the standard convention on Quest titles.
             new() { action = ScanAction.ToggleDebugMenu,     button = OVRInput.Button.PrimaryThumbstick, enabled = true },
             new() { action = ScanAction.FreezeInView,        button = OVRInput.Button.One,   enabled = true },
             new() { action = ScanAction.UnfreezeInView,      button = OVRInput.Button.Two,   enabled = true },


### PR DESCRIPTION
The previous comment claimed Horizon OS intercepts OVRInput.Button.Start, which is incorrect — only the right Meta/Oculus logo button is reserved by the OS. The left ≡ button is free for host apps to bind to their own pause menu (the standard Quest convention).

The thumbstick-click choice for ToggleDebugMenu remains intentional: it leaves Button.Start untouched so host apps can claim it without fighting the scan SDK.

Made-with: Cursor