### PR TITLE
perf: defer ~600 MB scan GPU allocations until first scan/save/full-load

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -494,7 +494,7 @@ Per mesh extraction cycle, `UpdatePlateauDetection` tracks:
 ## 12b. Depth Subsystem Gating
 
 `DepthCapture` manages the `AROcclusionManager` lifecycle to avoid unnecessary GPU work:
-- **`StartDepthCapture()`**: Enables `AROcclusionManager`, subscribes to `frameReceived`. Called by `RoomScanner.StartScanning()`.
+- **`StartDepthCapture()`**: Enables `AROcclusionManager`, subscribes to `frameReceived`. Called by `RoomScanner.StartScanningAsync()`.
 - **`StopDepthCapture()`**: Unsubscribes, disables `AROcclusionManager` (calls `subsystem.Stop()` — shuts down depth sensor and neural inference on Quest). Called by `RoomScanner.StopScanning()`.
 - **`_permissionReady`**: Set once after USE_SCENE permission is confirmed and subsystem verified.
 - **`_captureActive`**: Persists across app pause/resume. `OnApplicationPause(false)` only re-enables the subsystem if `_captureActive` was true.

--- a/Editor/RoomScanSetupWizard.cs
+++ b/Editor/RoomScanSetupWizard.cs
@@ -780,7 +780,45 @@ namespace Genesis.RoomScan.Editor
                     Undo.RegisterCreatedObjectUndo(root, "Create RoomScan");
                 }
             }
+
+            EnsureRoomScanIdentityTransform(root);
             return root;
+        }
+
+        // The RoomScan GameObject MUST have an identity local transform.
+        // RoomScanner spawns a child "RefinedMeshRenderer" whose mesh
+        // vertices are pre-baked into world-space coordinates by
+        // RoomScanPersistence.RelocateVertices, and RefinedMesh.shader
+        // bypasses the object-to-world matrix (uses posWS directly). Unity
+        // still uses localToWorldMatrix for frustum-cull bounds, so any
+        // non-identity scale on this GameObject silently shrinks (or moves)
+        // the culling box away from the actual geometry — the rendered mesh
+        // then "disappears" from most viewing angles unless the camera
+        // frustum happens to clip the displaced bounds. Reset defensively.
+        static void EnsureRoomScanIdentityTransform(GameObject root)
+        {
+            if (root == null) return;
+            var t = root.transform;
+
+            bool wrongScale = t.localScale != Vector3.one;
+            bool wrongPos = t.localPosition != Vector3.zero;
+            bool wrongRot = t.localRotation != Quaternion.identity;
+            if (!wrongScale && !wrongPos && !wrongRot) return;
+
+            Undo.RecordObject(t, "Reset RoomScan transform to identity");
+            t.localScale = Vector3.one;
+            t.localPosition = Vector3.zero;
+            t.localRotation = Quaternion.identity;
+            EditorUtility.SetDirty(root);
+
+            Debug.LogWarning(
+                $"[RoomScanSetupWizard] Reset '{root.name}' transform to identity " +
+                $"(wrongScale={wrongScale}, wrongPos={wrongPos}, wrongRot={wrongRot}). " +
+                "RoomScanner's refined-mesh renderer hosts pre-baked world-space " +
+                "vertices and bypasses object-to-world in its shader; any non-identity " +
+                "parent transform breaks frustum-cull bounds and the mesh disappears " +
+                "from most viewing angles. Don't put world-space UI panels (UIDocument) " +
+                "directly on RoomScan — keep them on their own child GameObject.");
         }
 
         void FixCoreComponents()

--- a/Editor/RoomScanSetupWizard.cs
+++ b/Editor/RoomScanSetupWizard.cs
@@ -945,7 +945,7 @@ namespace Genesis.RoomScan.Editor
             StatusRowOptional("PassthroughCameraProvider", hasPCAProvider);
             StatusRowOptional("TextureRefinement (atlas baking)", hasRefinement);
             StatusRowOptional("RoomUnderstanding (MRUK bridge)", hasRoomUnderstanding);
-            StatusRowOptional("RoomScanSession (game-dev async API: StartScan / FinalizeScanAsync / LoadLatestAsync)",
+            StatusRowOptional("RoomScanSession (game-dev async API: StartScanAsync / FinalizeScanAsync / LoadLatestAsync)",
                               _session != null);
 
             if (hasRefinement)
@@ -1193,7 +1193,7 @@ namespace Genesis.RoomScan.Editor
             if (root.GetComponent<RoomUnderstanding>() == null)
                 Undo.AddComponent<RoomUnderstanding>(root);
 
-            // RoomScanSession: public game-dev facade (StartScan / FinalizeScanAsync /
+            // RoomScanSession: public game-dev facade (StartScanAsync / FinalizeScanAsync /
             // LoadLatestAsync / HasSavedScan / ProgressUpdated). Without it,
             // game code that follows the documented public-API path cannot
             // find RoomScanSession.Instance and bails.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Both optional dependencies can be combined. The `Genesis.RoomScan.AIDetection` a
 
 ### Scanning
 
-Call `RoomScanner.Instance.StartScanning()` to begin (or use the debug menu). As you look around:
+Call `await RoomScanner.Instance.StartScanningAsync()` to begin (or use the debug menu). As you look around:
 
 1. **Depth integration**: Each depth frame is fused into the TSDF volume with color from the passthrough camera
 2. **Mesh extraction**: GPU Surface Nets extracts a mesh from the volume every few frames (after a minimum number of integrations)
@@ -487,7 +487,11 @@ if (session.HasSavedScan)
     await session.ClearAllScansAsync();
 
 // 2. Begin scanning. The room mesh builds in real-time as the user looks around.
-session.StartScan();
+//    Awaitable: StartScanAsync stages the heavy GPU bring-up across ~4 yielded
+//    frames (~56 ms total) before enabling the passthrough camera, so PCA's
+//    hardware-buffer handshake doesn't race our compute dispatches and tank
+//    MRUK/Vulkan. Below human-perception threshold for "press registered".
+await session.StartScanAsync();
 session.ProgressUpdated += p => progressBar.value = p.OverallProgress;
 
 // 3. As the user sweeps the room, paint visible chunks as "done":
@@ -517,7 +521,7 @@ if (session.HasSavedScan)
 
 `FinalizeScanAsync()` handles everything: stop scanning → texture refinement → save to disk → release GPU resources. The scan is also persisted as a self-contained package under `Application.persistentDataPath/RoomScans/pkg_<timestamp>/` with its own `OVRSpatialAnchor` for cross-session relocation.
 
-> **Why explicit permission gating matters.** PCA's own `OnEnable` waits for the user's permission decision in a coroutine, so the scan eventually transitions to RGB mode after the user accepts. But during the wait, `RoomScanner.StartScanning()` has already kicked off integration in degraded depth-only mode, and there's no place for game UI to show an "asking for permission" state. Calling `await session.RequestCameraPermissionAsync()` *before* `StartScan()` lets you surface a deterministic UI state and only kick off integration once you actually have the camera.
+> **Why explicit permission gating matters.** PCA's own `OnEnable` waits for the user's permission decision in a coroutine, so the scan eventually transitions to RGB mode after the user accepts. But during the wait, `RoomScanner.StartScanningAsync()` has already kicked off integration in degraded depth-only mode, and there's no place for game UI to show an "asking for permission" state. Calling `await session.RequestCameraPermissionAsync()` *before* `StartScanAsync()` lets you surface a deterministic UI state and only kick off integration once you actually have the camera.
 
 > **Why `ClearAllScansAsync` and not save-then-purge.** `ClearAllScansAsync` deliberately wipes only saved packages (`pkg_*/` and `manifest.json`), never the active `_tmp/` working directory — that one is owned by `StartScan` / `FinalizeScanAsync`'s lifecycle. Safe to call at any point: if nothing is saved it returns immediately. The trade-off is that a finalize crash after a `ClearAllScansAsync` loses the previous scan; if your game wants the old scan to outlive a finalize failure, save first and purge after.
 
@@ -526,7 +530,7 @@ if (session.HasSavedScan)
 For developers who want finer control, the underlying APIs are:
 
 ```
-1. Scan Phase:    StartScanning() → user looks around → StopScanning()
+1. Scan Phase:    await StartScanningAsync() → user looks around → StopScanning()
 2. Refine:        StartTextureRefinement() → wait for RefinedMeshReady event
 3. Transition:    ReleaseScanResources() → frees ~400-500 MB GPU memory
 4. Game Phase:    Render with standard MeshRenderer (1 draw call, baked texture)
@@ -593,7 +597,7 @@ scanner.ReleaseScanResources();
 // Vertex/Wireframe/Triplanar modes become unavailable (IsModeAvailable returns false)
 
 // To scan again later (re-allocates everything):
-scanner.StartScanning();
+await scanner.StartScanningAsync();
 ```
 
 #### Monitoring Scan Progress
@@ -644,7 +648,7 @@ Everything a game needs lives on one component. `[RequireComponent(typeof(RoomSc
 1. Add QuestRoomScan to your `Packages/manifest.json` (see [Installation](#installation)).
 2. Open **`RoomScan > Setup Scene`** and click **`Apply Game-Ready Setup`**. Re-click after the build-target / domain reload to finish.
 3. Build to Quest 3 (or attach Quest Link).
-4. Game code: `await RoomScanSession.Instance.RequestCameraPermissionAsync();` then `RoomScanSession.Instance.StartScan();`.
+4. Game code: `await RoomScanSession.Instance.RequestCameraPermissionAsync();` then `await RoomScanSession.Instance.StartScanAsync();`.
 5. Bind a controller button to `FreezeInView` and another to `UnfreezeInView` (the QRS DebugMenu uses Y/B + X/A by default).
 6. When the user commits: `var result = await RoomScanSession.Instance.FinalizeScanAsync();` → use `result.Mesh` + `result.Atlas` to render with a standard `MeshRenderer`.
 7. On subsequent launches: `if (session.HasSavedScan) await session.LoadLatestAsync();` — skip scanning entirely.

--- a/Runtime/Core/MeshExtractor.cs
+++ b/Runtime/Core/MeshExtractor.cs
@@ -105,16 +105,6 @@ namespace Genesis.RoomScan
 
         private void Init()
         {
-            // ── Instrumentation ─────────────────────────────────────────
-            // EnsureBuffers allocates ~480 MB of ComputeBuffers and
-            // uploads the Surface Nets cell-table — the largest single
-            // GPU allocation in the entire scan path. Field reports of
-            // a "permanent hang" on first A-press make this the prime
-            // suspect. Per-step timing tells us whether the cost is in
-            // the buffer alloc, the GPUMeshRenderer AddComponent, or
-            // its Initialize. Remove after the warmup path is verified.
-            var sw = System.Diagnostics.Stopwatch.StartNew();
-
             _gpuSurfaceNets = new GPUSurfaceNets(surfaceNetsCompute)
             {
                 MinMeshWeight = _volume.MinMeshWeight,
@@ -127,20 +117,12 @@ namespace Genesis.RoomScan
                 ConvergenceThreshold = convergenceThreshold,
                 TemporalDeadzone = temporalDeadzone
             };
-            Logger.Info($"MeshExtractor.Init: new GPUSurfaceNets ctor took {sw.ElapsedMilliseconds} ms");
-            sw.Restart();
 
             _gpuSurfaceNets.EnsureBuffers(_volume.VoxelCount, gpuVertexBudgetPercent);
-            Logger.Info($"MeshExtractor.Init: GPUSurfaceNets.EnsureBuffers (~480 MB ComputeBuffers) took {sw.ElapsedMilliseconds} ms");
-            sw.Restart();
 
             _gpuRenderer = gameObject.AddComponent<GPUMeshRenderer>();
             _gpuRenderer.GpuMeshMaterial = scanMeshMaterial;
-            Logger.Info($"MeshExtractor.Init: AddComponent<GPUMeshRenderer> + material took {sw.ElapsedMilliseconds} ms");
-            sw.Restart();
-
             _gpuRenderer.Initialize(_gpuSurfaceNets, _gpuSurfaceNets.GetVolumeBounds(_volume.VoxelSize));
-            Logger.Info($"MeshExtractor.Init: GPUMeshRenderer.Initialize took {sw.ElapsedMilliseconds} ms");
 
             Logger.Info($"GPU Surface Nets initialized lazily: voxels={_volume.VoxelCount}, " +
                       $"voxSize={_volume.VoxelSize}");

--- a/Runtime/Core/MeshExtractor.cs
+++ b/Runtime/Core/MeshExtractor.cs
@@ -69,12 +69,31 @@ namespace Genesis.RoomScan
             if (surfaceNetsCompute == null)
                 throw new Exception("[RoomScan] surfaceNetsCompute not assigned on MeshExtractor");
 
+            // GPU Surface Nets buffers (~480 MB at the default 256³ voxel grid)
+            // are allocated lazily — first scan via RoomScanner.StartScanning,
+            // or full-load via RoomScanPersistence.LoadPackageAsync. Pure
+            // refined-mesh-only replay paths never trigger this. Keep the
+            // pipeline log here so device traces still show RP/stereo/material
+            // state at scene load, but defer the heavy Init().
             var rpAsset = GraphicsSettings.currentRenderPipeline;
-            Logger.Info($"MeshExtractor Start: mat={scanMeshMaterial?.name ?? "NULL"}, " +
+            Logger.Info($"MeshExtractor Start (Surface Nets buffers deferred): " +
+                $"mat={scanMeshMaterial?.name ?? "NULL"}, " +
                 $"shader={scanMeshMaterial?.shader?.name ?? "NULL"}, " +
                 $"rp={rpAsset?.name ?? "NULL"}, " +
                 $"stereoMode={UnityEngine.XR.XRSettings.stereoRenderingMode}");
+        }
 
+        /// <summary>
+        /// Lazy initializer. Brings up GPU Surface Nets buffers + the renderer
+        /// component if they aren't already up. Idempotent. Existing callers
+        /// (<see cref="Reinitialize"/>, <see cref="RoomScanner"/>'s update loop
+        /// guard, the Start of every scan) all funnel through here so the
+        /// allocation cost only appears when a scan or full reload actually
+        /// needs it.
+        /// </summary>
+        public void EnsureInitialized()
+        {
+            if (_gpuSurfaceNets != null) return;
             Init();
         }
 
@@ -104,7 +123,7 @@ namespace Genesis.RoomScan
             _gpuRenderer.GpuMeshMaterial = scanMeshMaterial;
             _gpuRenderer.Initialize(_gpuSurfaceNets, _gpuSurfaceNets.GetVolumeBounds(_volume.VoxelSize));
 
-            Logger.Info($"GPU Surface Nets initialized: voxels={_volume.VoxelCount}, " +
+            Logger.Info($"GPU Surface Nets initialized lazily: voxels={_volume.VoxelCount}, " +
                       $"voxSize={_volume.VoxelSize}");
         }
 

--- a/Runtime/Core/MeshExtractor.cs
+++ b/Runtime/Core/MeshExtractor.cs
@@ -105,6 +105,16 @@ namespace Genesis.RoomScan
 
         private void Init()
         {
+            // ── Instrumentation ─────────────────────────────────────────
+            // EnsureBuffers allocates ~480 MB of ComputeBuffers and
+            // uploads the Surface Nets cell-table — the largest single
+            // GPU allocation in the entire scan path. Field reports of
+            // a "permanent hang" on first A-press make this the prime
+            // suspect. Per-step timing tells us whether the cost is in
+            // the buffer alloc, the GPUMeshRenderer AddComponent, or
+            // its Initialize. Remove after the warmup path is verified.
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+
             _gpuSurfaceNets = new GPUSurfaceNets(surfaceNetsCompute)
             {
                 MinMeshWeight = _volume.MinMeshWeight,
@@ -117,11 +127,20 @@ namespace Genesis.RoomScan
                 ConvergenceThreshold = convergenceThreshold,
                 TemporalDeadzone = temporalDeadzone
             };
+            Logger.Info($"MeshExtractor.Init: new GPUSurfaceNets ctor took {sw.ElapsedMilliseconds} ms");
+            sw.Restart();
+
             _gpuSurfaceNets.EnsureBuffers(_volume.VoxelCount, gpuVertexBudgetPercent);
+            Logger.Info($"MeshExtractor.Init: GPUSurfaceNets.EnsureBuffers (~480 MB ComputeBuffers) took {sw.ElapsedMilliseconds} ms");
+            sw.Restart();
 
             _gpuRenderer = gameObject.AddComponent<GPUMeshRenderer>();
             _gpuRenderer.GpuMeshMaterial = scanMeshMaterial;
+            Logger.Info($"MeshExtractor.Init: AddComponent<GPUMeshRenderer> + material took {sw.ElapsedMilliseconds} ms");
+            sw.Restart();
+
             _gpuRenderer.Initialize(_gpuSurfaceNets, _gpuSurfaceNets.GetVolumeBounds(_volume.VoxelSize));
+            Logger.Info($"MeshExtractor.Init: GPUMeshRenderer.Initialize took {sw.ElapsedMilliseconds} ms");
 
             Logger.Info($"GPU Surface Nets initialized lazily: voxels={_volume.VoxelCount}, " +
                       $"voxSize={_volume.VoxelSize}");

--- a/Runtime/Core/RoomScanPersistence.cs
+++ b/Runtime/Core/RoomScanPersistence.cs
@@ -744,6 +744,10 @@ namespace Genesis.RoomScan
                 mesh.SetUVs(0, displayData.UVs);
                 mesh.SetTriangles(displayData.Indices, 0);
                 mesh.RecalculateTangents();
+                // Frustum culling needs real bounds; without this the mesh
+                // is treated as a zero-size point at the local origin and
+                // pops in/out depending on view direction.
+                mesh.RecalculateBounds();
 
                 scanner.ApplyRefinedTexture(atlasTex, mesh, normalTex);
                 Logger.Info($"Refined atlas loaded ({meshData.AtlasWidth}x{meshData.AtlasHeight})" +

--- a/Runtime/Core/RoomScanPersistence.cs
+++ b/Runtime/Core/RoomScanPersistence.cs
@@ -225,10 +225,24 @@ namespace Genesis.RoomScan
         public async Task<bool> SaveToNewPackageAsync()
         {
             var vi = VolumeIntegrator.Instance;
-            if (vi == null || vi.Volume == null)
+            if (vi == null)
             {
-                Logger.Warning("Cannot save, no volume");
+                Logger.Warning("Cannot save, VolumeIntegrator instance missing");
                 return false;
+            }
+            // Defensive: if a caller invokes Save without ever StartScanning
+            // (programmatic snapshot, test runner, etc.) the volume RTs will
+            // be null because of lazy alloc. ReallocateVolumes is idempotent.
+            // We don't fabricate scan data — if the volume is empty the saved
+            // payload will reflect that.
+            if (vi.Volume == null)
+            {
+                vi.ReallocateVolumes();
+                if (vi.Volume == null)
+                {
+                    Logger.Warning("Cannot save, ReallocateVolumes did not produce a Volume RT");
+                    return false;
+                }
             }
             if (IsSaving) { Logger.Warning("Save already in progress"); return false; }
 
@@ -814,9 +828,21 @@ namespace Genesis.RoomScan
 
             var vi = VolumeIntegrator.Instance;
             var cm = MeshExtractor.Instance;
-            if (vi == null || vi.Volume == null)
+            if (vi == null)
             {
-                Logger.Warning("Cannot load, no volume");
+                Logger.Warning("Cannot load, VolumeIntegrator instance missing");
+                return false;
+            }
+            // Full-load path needs the GPU TSDF volume to receive the saved
+            // bytes. With lazy alloc the volume may not exist yet (e.g. user
+            // skipped past startup straight into "load saved scan for
+            // re-editing" via the debug menu). Bring it up on demand —
+            // idempotent if already allocated.
+            if (vi.Volume == null) vi.ReallocateVolumes();
+            if (cm != null) cm.EnsureInitialized();
+            if (vi.Volume == null)
+            {
+                Logger.Warning("Cannot load, ReallocateVolumes did not produce a Volume RT");
                 return false;
             }
             if (IsLoading) { Logger.Warning("Load already in progress"); return false; }

--- a/Runtime/Core/RoomScanner.cs
+++ b/Runtime/Core/RoomScanner.cs
@@ -447,6 +447,96 @@ namespace Genesis.RoomScan
         // ═════════════════════════════════════════════════════════════
 
         /// <summary>
+        /// Pre-allocates the heavy scan GPU resources (~150 MB TSDF/color
+        /// volumes + ~480 MB Surface Nets buffers + first-dispatch kernel
+        /// warmup) <b>without</b> starting integration. Idempotent.
+        ///
+        /// <para>
+        /// <b>Why it exists.</b> The lazy-alloc landed in
+        /// <c>perf/lazy-scan-gpu-allocations</c> moved this work from
+        /// <c>Awake</c>/<c>Start</c> (where the boot splash hides any
+        /// stall) into the first <see cref="StartScanning"/> call. On
+        /// device that landed inside the user's A-press frame and burned
+        /// 1–3 s on the main thread because Vulkan has to drain in-flight
+        /// frames before the new descriptor pool can include the freshly
+        /// created 3D RTs and ComputeBuffers. Result: head-locked freeze,
+        /// motion sickness, and ANR risk.
+        /// </para>
+        ///
+        /// <para>
+        /// <b>How to use.</b> Host apps with a "scan-guidance" UX (the
+        /// user reads hints for several seconds before pressing A) should
+        /// call this as soon as that surface becomes visible. The cost
+        /// then amortises across that idle window instead of landing in a
+        /// single frame. <see cref="StartScanning"/> remains correct on
+        /// its own — this is a pure optimisation. Both <c>VolumeIntegrator</c>
+        /// and <c>MeshExtractor</c> ignore re-allocation when they are
+        /// already up, so calling it more than once is free.
+        /// </para>
+        ///
+        /// <para>
+        /// We yield twice between the volume and mesh allocation steps so
+        /// the compositor gets at least one full frame to recover before
+        /// the next 480 MB allocation lands. Awaiting <see cref="Task.Yield"/>
+        /// from a Unity main-thread coroutine context resumes on the main
+        /// thread on the next frame, so the GPU work happens in three
+        /// well-separated frames instead of one mega-frame.
+        /// </para>
+        /// </summary>
+        public async Task WarmupScanResourcesAsync()
+        {
+            if (IsScanning)
+            {
+                // An active scan already owns these resources; nothing to warm.
+                return;
+            }
+            if (_volumeIntegrator == null || _meshExtractor == null)
+            {
+                Logger.Warning("RoomScanner.WarmupScanResourcesAsync: scanner " +
+                               "not fully initialised yet (no integrator/extractor).");
+                return;
+            }
+
+            bool needVolumes = _volumeIntegrator.VolumesReleased;
+            bool needMesh = !_meshExtractor.IsInitialized;
+            if (!needVolumes && !needMesh)
+            {
+                _scanResourcesReleased = false;
+                return;
+            }
+
+            Logger.Info($"RoomScanner.WarmupScanResourcesAsync: warming GPU " +
+                        $"resources during idle window (needVolumes={needVolumes}, " +
+                        $"needMesh={needMesh}).");
+
+            if (needVolumes)
+            {
+                _volumeIntegrator.ReallocateVolumes();
+                // Two yields: first frame absorbs the RT.Create + Clear
+                // dispatch, second frame lets the compositor re-stabilise
+                // before the much larger Surface Nets alloc lands.
+                await Task.Yield();
+                await Task.Yield();
+            }
+
+            if (needMesh)
+            {
+                _meshExtractor.EnsureInitialized();
+                await Task.Yield();
+                await Task.Yield();
+            }
+
+            // Critical: must clear the released flag, otherwise the next
+            // StartScanning() takes the `_scanResourcesReleased` branch and
+            // calls MeshExtractor.Reinitialize() — which destroys + recreates
+            // the very buffers we just warmed up, defeating the optimisation.
+            _scanResourcesReleased = false;
+
+            Logger.Info("RoomScanner.WarmupScanResourcesAsync: scan GPU " +
+                        "resources warmed; first scan press will be hang-free.");
+        }
+
+        /// <summary>
         /// Begins depth integration and mesh extraction. Resets relocation state,
         /// clears in-memory keyframes, and starts the active camera provider.
         /// </summary>
@@ -456,6 +546,22 @@ namespace Genesis.RoomScan
             IsScanning = true;
             KeyframeRelocation = Matrix4x4.identity;
             _cachedUnwrap = null;
+
+            // ── Instrumentation ─────────────────────────────────────────
+            // The lazy-alloc landing in `perf/lazy-scan-gpu-allocations`
+            // moved ~600 MB of GPU work from `Awake`/`Start` (where the
+            // boot splash absorbs any stall) into the user's A-press
+            // frame. Field reports describe a "permanent hang that never
+            // recovers" instead of a 1–3 s freeze, which doesn't match
+            // a pure GPU-cost story (GPU allocs eventually return). The
+            // timing logs below were added so the next hung session's
+            // logcat tells us *which* call wedges the main thread —
+            // ReallocateVolumes (TSDF/color RTs), EnsureInitialized
+            // (Surface Nets buffers + first dispatch), CreateTmpPackage
+            // (file I/O), or one of the camera-provider starts.
+            // Remove once the warmup path lands and is verified.
+            var swTotal = System.Diagnostics.Stopwatch.StartNew();
+            var sw = System.Diagnostics.Stopwatch.StartNew();
 
             // Lazy GPU bring-up. Both calls are idempotent: ReallocateVolumes
             // early-returns if RTs already exist, and EnsureInitialized
@@ -471,14 +577,21 @@ namespace Genesis.RoomScan
             if (_scanResourcesReleased)
             {
                 _volumeIntegrator.ReallocateVolumes();
+                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: ReallocateVolumes (post-release) took {sw.ElapsedMilliseconds} ms");
+                sw.Restart();
                 _meshExtractor.Reinitialize();
+                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: Mesh Reinitialize took {sw.ElapsedMilliseconds} ms");
                 _scanResourcesReleased = false;
             }
             else
             {
                 _volumeIntegrator.ReallocateVolumes();
+                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: ReallocateVolumes took {sw.ElapsedMilliseconds} ms");
+                sw.Restart();
                 _meshExtractor.EnsureInitialized();
+                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: EnsureInitialized took {sw.ElapsedMilliseconds} ms");
             }
+            sw.Restart();
 
             // Resume within the same session: if we already have an active tmp
             // package with scan data, keep it instead of nuking everything.
@@ -533,7 +646,11 @@ namespace Genesis.RoomScan
                     _keyframeCollector.ClearInMemory();
 
                 _persistence.CreateTmpPackage();
+                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: CreateTmpPackage took {sw.ElapsedMilliseconds} ms");
+                sw.Restart();
                 _ = CreateScanAnchorAsync();
+                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: CreateScanAnchorAsync (fire-and-forget) launch took {sw.ElapsedMilliseconds} ms");
+                sw.Restart();
             }
 
             _keyframeCollector?.SetExportDirectory(
@@ -547,7 +664,11 @@ namespace Genesis.RoomScan
 
             ICameraProvider provider = GetActiveCameraProvider();
             provider?.StartCapture();
+            Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: camera StartCapture took {sw.ElapsedMilliseconds} ms");
+            sw.Restart();
             _depthCapture.StartDepthCapture();
+            Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: DepthCapture.StartDepthCapture took {sw.ElapsedMilliseconds} ms");
+            sw.Restart();
 
             if (!resuming)
             {
@@ -566,6 +687,12 @@ namespace Genesis.RoomScan
             ScanStarted?.Invoke();
             if (_modules != null)
                 foreach (var m in _modules) m.OnScanStarted();
+
+            Logger.Info($"StartScanning RETURNED — total main-thread time {swTotal.ElapsedMilliseconds} ms. " +
+                        "If field reports describe a >5 s 'permanent hang' this is the upper " +
+                        "bound on the synchronous part; anything beyond that is fire-and-forget " +
+                        "(spatial anchor handshake) or compositor / OVR runtime giving up after " +
+                        "the long stall.");
         }
 
         /// <summary>

--- a/Runtime/Core/RoomScanner.cs
+++ b/Runtime/Core/RoomScanner.cs
@@ -34,7 +34,7 @@ namespace Genesis.RoomScan
     /// <summary>High-level phase of the scanning session.</summary>
     public enum ScanPhase
     {
-        /// <summary>Before <see cref="RoomScanner.StartScanning"/> is called.</summary>
+        /// <summary>Before <see cref="RoomScanner.StartScanningAsync"/> is called.</summary>
         NotStarted,
         /// <summary>New geometry appearing rapidly — early scan.</summary>
         Discovering,
@@ -447,252 +447,218 @@ namespace Genesis.RoomScan
         // ═════════════════════════════════════════════════════════════
 
         /// <summary>
-        /// Pre-allocates the heavy scan GPU resources (~150 MB TSDF/color
-        /// volumes + ~480 MB Surface Nets buffers + first-dispatch kernel
-        /// warmup) <b>without</b> starting integration. Idempotent.
-        ///
-        /// <para>
-        /// <b>Why it exists.</b> The lazy-alloc landed in
-        /// <c>perf/lazy-scan-gpu-allocations</c> moved this work from
-        /// <c>Awake</c>/<c>Start</c> (where the boot splash hides any
-        /// stall) into the first <see cref="StartScanning"/> call. On
-        /// device that landed inside the user's A-press frame and burned
-        /// 1–3 s on the main thread because Vulkan has to drain in-flight
-        /// frames before the new descriptor pool can include the freshly
-        /// created 3D RTs and ComputeBuffers. Result: head-locked freeze,
-        /// motion sickness, and ANR risk.
-        /// </para>
-        ///
-        /// <para>
-        /// <b>How to use.</b> Host apps with a "scan-guidance" UX (the
-        /// user reads hints for several seconds before pressing A) should
-        /// call this as soon as that surface becomes visible. The cost
-        /// then amortises across that idle window instead of landing in a
-        /// single frame. <see cref="StartScanning"/> remains correct on
-        /// its own — this is a pure optimisation. Both <c>VolumeIntegrator</c>
-        /// and <c>MeshExtractor</c> ignore re-allocation when they are
-        /// already up, so calling it more than once is free.
-        /// </para>
-        ///
-        /// <para>
-        /// We yield twice between the volume and mesh allocation steps so
-        /// the compositor gets at least one full frame to recover before
-        /// the next 480 MB allocation lands. Awaiting <see cref="Task.Yield"/>
-        /// from a Unity main-thread coroutine context resumes on the main
-        /// thread on the next frame, so the GPU work happens in three
-        /// well-separated frames instead of one mega-frame.
-        /// </para>
-        /// </summary>
-        public async Task WarmupScanResourcesAsync()
-        {
-            if (IsScanning)
-            {
-                // An active scan already owns these resources; nothing to warm.
-                return;
-            }
-            if (_volumeIntegrator == null || _meshExtractor == null)
-            {
-                Logger.Warning("RoomScanner.WarmupScanResourcesAsync: scanner " +
-                               "not fully initialised yet (no integrator/extractor).");
-                return;
-            }
-
-            bool needVolumes = _volumeIntegrator.VolumesReleased;
-            bool needMesh = !_meshExtractor.IsInitialized;
-            if (!needVolumes && !needMesh)
-            {
-                _scanResourcesReleased = false;
-                return;
-            }
-
-            Logger.Info($"RoomScanner.WarmupScanResourcesAsync: warming GPU " +
-                        $"resources during idle window (needVolumes={needVolumes}, " +
-                        $"needMesh={needMesh}).");
-
-            if (needVolumes)
-            {
-                _volumeIntegrator.ReallocateVolumes();
-                // Two yields: first frame absorbs the RT.Create + Clear
-                // dispatch, second frame lets the compositor re-stabilise
-                // before the much larger Surface Nets alloc lands.
-                await Task.Yield();
-                await Task.Yield();
-            }
-
-            if (needMesh)
-            {
-                _meshExtractor.EnsureInitialized();
-                await Task.Yield();
-                await Task.Yield();
-            }
-
-            // Critical: must clear the released flag, otherwise the next
-            // StartScanning() takes the `_scanResourcesReleased` branch and
-            // calls MeshExtractor.Reinitialize() — which destroys + recreates
-            // the very buffers we just warmed up, defeating the optimisation.
-            _scanResourcesReleased = false;
-
-            Logger.Info("RoomScanner.WarmupScanResourcesAsync: scan GPU " +
-                        "resources warmed; first scan press will be hang-free.");
-        }
-
-        /// <summary>
         /// Begins depth integration and mesh extraction. Resets relocation state,
         /// clears in-memory keyframes, and starts the active camera provider.
+        ///
+        /// <para>
+        /// <b>Async by necessity, not by API preference.</b> The lazy GPU
+        /// bring-up (~150 MB TSDF + ~480 MB Surface Nets) and the
+        /// passthrough-camera handshake (PCA → MRUK) are both heavy work
+        /// for the render thread, and if they land in the same Unity frame
+        /// PCA's hardware-buffer-queue handshake loses the race against
+        /// our compute dispatches: MRUK then spams "Hardware buffer queue
+        /// is empty", Vulkan submit corrupts with
+        /// VK_ERROR_INITIALIZATION_FAILED, and the compositor never
+        /// recovers (perceived as a permanent hang on the user's first
+        /// A-press). The fix is to do the GPU allocations + first
+        /// dispatches first, yield twice between each step so the render
+        /// thread commits the new resources across separate frames, and
+        /// only then enable PCA + AROcclusionManager. Total wall-clock
+        /// cost on a Quest 3 is ~56 ms (4 frames at 72 fps) — below the
+        /// "press registered" threshold of human perception.
+        /// </para>
+        ///
+        /// <para>
+        /// Eager allocation in <c>Awake</c>/<c>Start</c> avoided the bug
+        /// because the render thread had committed all VRAM and run the
+        /// first dispatches across multiple uneventful boot-splash frames
+        /// before the user could ever press A. The lazy-alloc landing
+        /// regressed that without realising the timing was load-bearing.
+        /// We keep lazy alloc (so the load-existing-scan path doesn't pay
+        /// the 600 MB cost) and add the inline staging instead.
+        /// </para>
         /// </summary>
-        public void StartScanning()
+        public async Task StartScanningAsync()
         {
             if (IsScanning) return;
             IsScanning = true;
-            KeyframeRelocation = Matrix4x4.identity;
-            _cachedUnwrap = null;
-
-            // ── Instrumentation ─────────────────────────────────────────
-            // The lazy-alloc landing in `perf/lazy-scan-gpu-allocations`
-            // moved ~600 MB of GPU work from `Awake`/`Start` (where the
-            // boot splash absorbs any stall) into the user's A-press
-            // frame. Field reports describe a "permanent hang that never
-            // recovers" instead of a 1–3 s freeze, which doesn't match
-            // a pure GPU-cost story (GPU allocs eventually return). The
-            // timing logs below were added so the next hung session's
-            // logcat tells us *which* call wedges the main thread —
-            // ReallocateVolumes (TSDF/color RTs), EnsureInitialized
-            // (Surface Nets buffers + first dispatch), CreateTmpPackage
-            // (file I/O), or one of the camera-provider starts.
-            // Remove once the warmup path lands and is verified.
-            var swTotal = System.Diagnostics.Stopwatch.StartNew();
-            var sw = System.Diagnostics.Stopwatch.StartNew();
-
-            // Lazy GPU bring-up. Both calls are idempotent: ReallocateVolumes
-            // early-returns if RTs already exist, and EnsureInitialized
-            // early-returns if Surface Nets buffers are already up. This
-            // covers three cases uniformly:
-            //   1. First-ever scan in this session — heavy alloc happens here
-            //      (~150 MB TSDF + ~480 MB Surface Nets), NOT at scene load.
-            //   2. Resume after ReleaseScanResources — same thing.
-            //   3. Already-allocated mid-session — no-op.
-            // Reinitialize on the mesh side disposes/recreates so we use
-            // EnsureInitialized for the no-op-if-up branch and Reinitialize
-            // only after an explicit release.
-            if (_scanResourcesReleased)
+            try
             {
-                _volumeIntegrator.ReallocateVolumes();
-                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: ReallocateVolumes (post-release) took {sw.ElapsedMilliseconds} ms");
-                sw.Restart();
-                _meshExtractor.Reinitialize();
-                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: Mesh Reinitialize took {sw.ElapsedMilliseconds} ms");
-                _scanResourcesReleased = false;
-            }
-            else
-            {
-                _volumeIntegrator.ReallocateVolumes();
-                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: ReallocateVolumes took {sw.ElapsedMilliseconds} ms");
-                sw.Restart();
-                _meshExtractor.EnsureInitialized();
-                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: EnsureInitialized took {sw.ElapsedMilliseconds} ms");
-            }
-            sw.Restart();
-
-            // Resume within the same session: if we already have an active tmp
-            // package with scan data, keep it instead of nuking everything.
-            bool resuming = _persistence != null
-                && _persistence.ActivePackageId == RoomScanPersistence.TmpPkgId
-                && _volumeIntegrator.IntegrationCount > 0;
-
-            if (!resuming)
-            {
-                _prevVertexCount = 0;
-                _stableVertexCycles = 0;
-                _stableColorCycles = 0;
-                _prevColorCoverage = 0f;
-                _stabilizedTime = 0f;
-
-                // Invalidate any previously loaded / refined output. Without
-                // this, a Begin() that follows a LoadRefinedOnlyAsync (or a
-                // prior in-session refinement) leaves HasRefinedTexture=true
-                // and the old _refinedMesh visible, which (a) keeps the stale
-                // mesh on screen instead of switching to live vertex preview
-                // and (b) makes RoomScanSession.FinalizeScanAsync skip the
-                // "if (!HasRefinedTexture) StartTextureRefinement()" gate, so
-                // the new TSDF gets saved but no fresh refined_mesh.bin is
-                // ever written. This is the same per-state-reset that
-                // ClearAllDataAsync does, just narrowed to the things a fresh
-                // scan must invalidate (volumes are already re-alloc'd above).
-                HasRefinedTexture = false;
-                HasHQRefinedTexture = false;
-                HasEnhancedMesh = false;
-                LastRefinedResult = null;
-                LastSimplifiedResult = null;
+                KeyframeRelocation = Matrix4x4.identity;
                 _cachedUnwrap = null;
-                _refinedMesh = null;
-                if (_normalMapTexture != null)
+
+                // ── Instrumentation ─────────────────────────────────────
+                // Per-step Stopwatch logs around every synchronous step so
+                // a future regression of the MRUK/Vulkan hang is easy to
+                // bisect. Will be removed in a follow-up commit once the
+                // staged-allocation fix is verified on device for both the
+                // first-scan and post-release-resume paths.
+                var swTotal = System.Diagnostics.Stopwatch.StartNew();
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+
+                // ── Stage 1: GPU volume bring-up ────────────────────────
+                // Both calls are idempotent: ReallocateVolumes early-returns
+                // if RTs already exist; EnsureInitialized / Reinitialize
+                // early-return for the same reason on the mesh side. The
+                // _scanResourcesReleased branch uses Reinitialize because
+                // ReleaseScanResources explicitly disposes the mesh
+                // extractor and we need a true rebuild, not a no-op.
+                if (_scanResourcesReleased)
                 {
-                    Destroy(_normalMapTexture);
-                    _normalMapTexture = null;
+                    _volumeIntegrator.ReallocateVolumes();
+                    Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: ReallocateVolumes (post-release) took {sw.ElapsedMilliseconds} ms");
                 }
-                _gsplatProvider?.ClearSplat();
-                _gsplatProvider?.ResetSplatTransform();
-                _downloadedPlyData = null;
-
-                // Switch render mode off Refined/HQRefined/Splat back to the
-                // live in-progress preview. Done after the HasRefined* flags
-                // are cleared so IsModeAvailable() reports the new state
-                // correctly and the renderer toggles in ApplyRenderMode pick
-                // up Vertex as the right visible mode.
-                SetRenderMode(ScanRenderMode.Vertex);
-
-                if (_persistence != null) _persistence.ClearActivePackage();
-                if (_keyframeCollector != null)
-                    _keyframeCollector.ClearInMemory();
-
-                _persistence.CreateTmpPackage();
-                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: CreateTmpPackage took {sw.ElapsedMilliseconds} ms");
+                else
+                {
+                    _volumeIntegrator.ReallocateVolumes();
+                    Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: ReallocateVolumes took {sw.ElapsedMilliseconds} ms");
+                }
                 sw.Restart();
-                _ = CreateScanAnchorAsync();
-                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: CreateScanAnchorAsync (fire-and-forget) launch took {sw.ElapsedMilliseconds} ms");
+
+                // Yield twice so the render thread can (a) actually commit
+                // the two 256³ 3D RT allocations to VRAM, and (b) run the
+                // first Clear compute dispatch. One yield is "next frame";
+                // two yields gives the compositor a clean frame in between
+                // before the much bigger Surface Nets alloc lands.
+                await Task.Yield();
+                await Task.Yield();
+
+                // ── Stage 2: Surface Nets mesh extractor ────────────────
+                if (_scanResourcesReleased)
+                {
+                    _meshExtractor.Reinitialize();
+                    Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: Mesh Reinitialize took {sw.ElapsedMilliseconds} ms");
+                    _scanResourcesReleased = false;
+                }
+                else
+                {
+                    _meshExtractor.EnsureInitialized();
+                    Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: EnsureInitialized took {sw.ElapsedMilliseconds} ms");
+                }
                 sw.Restart();
+
+                // Yield twice so the render thread can commit the ~480 MB
+                // ComputeBuffers + cell-table upload before PCA enables.
+                // This is the critical pair — without it, PCA's native
+                // OnEnable lands in the same frame as the first Surface
+                // Nets dispatch and the MRUK fence handshake fails.
+                await Task.Yield();
+                await Task.Yield();
+
+                // ── Stage 3: persistence + per-scan invalidation ────────
+                // Resume within the same session: if we already have an
+                // active tmp package with scan data, keep it instead of
+                // nuking everything.
+                bool resuming = _persistence != null
+                    && _persistence.ActivePackageId == RoomScanPersistence.TmpPkgId
+                    && _volumeIntegrator.IntegrationCount > 0;
+
+                if (!resuming)
+                {
+                    _prevVertexCount = 0;
+                    _stableVertexCycles = 0;
+                    _stableColorCycles = 0;
+                    _prevColorCoverage = 0f;
+                    _stabilizedTime = 0f;
+
+                    // Invalidate any previously loaded / refined output. Without
+                    // this, a Begin() that follows a LoadRefinedOnlyAsync (or a
+                    // prior in-session refinement) leaves HasRefinedTexture=true
+                    // and the old _refinedMesh visible, which (a) keeps the stale
+                    // mesh on screen instead of switching to live vertex preview
+                    // and (b) makes RoomScanSession.FinalizeScanAsync skip the
+                    // "if (!HasRefinedTexture) StartTextureRefinement()" gate, so
+                    // the new TSDF gets saved but no fresh refined_mesh.bin is
+                    // ever written. This is the same per-state-reset that
+                    // ClearAllDataAsync does, just narrowed to the things a fresh
+                    // scan must invalidate (volumes are already re-alloc'd above).
+                    HasRefinedTexture = false;
+                    HasHQRefinedTexture = false;
+                    HasEnhancedMesh = false;
+                    LastRefinedResult = null;
+                    LastSimplifiedResult = null;
+                    _cachedUnwrap = null;
+                    _refinedMesh = null;
+                    if (_normalMapTexture != null)
+                    {
+                        Destroy(_normalMapTexture);
+                        _normalMapTexture = null;
+                    }
+                    _gsplatProvider?.ClearSplat();
+                    _gsplatProvider?.ResetSplatTransform();
+                    _downloadedPlyData = null;
+
+                    // Switch render mode off Refined/HQRefined/Splat back to the
+                    // live in-progress preview. Done after the HasRefined* flags
+                    // are cleared so IsModeAvailable() reports the new state
+                    // correctly and the renderer toggles in ApplyRenderMode pick
+                    // up Vertex as the right visible mode.
+                    SetRenderMode(ScanRenderMode.Vertex);
+
+                    if (_persistence != null) _persistence.ClearActivePackage();
+                    if (_keyframeCollector != null)
+                        _keyframeCollector.ClearInMemory();
+
+                    _persistence.CreateTmpPackage();
+                    Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: CreateTmpPackage took {sw.ElapsedMilliseconds} ms");
+                    sw.Restart();
+                    _ = CreateScanAnchorAsync();
+                    Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: CreateScanAnchorAsync (fire-and-forget) launch took {sw.ElapsedMilliseconds} ms");
+                    sw.Restart();
+                }
+
+                _keyframeCollector?.SetExportDirectory(
+                    Path.Combine(_persistence.ActivePackageDirectory, "keyframes"));
+
+                float t = Time.time;
+                _lastIntegrationTime = t;
+                _lastMeshTime = t;
+
+                _cameraAvailable = false;
+
+                // ── Stage 4: camera + depth (now safe) ──────────────────
+                // PCA's native OnEnable handshakes with MRUK to grab the
+                // passthrough hardware buffer queue. By this point the
+                // GPU resources are committed and the render-thread queue
+                // is clean, so PCA can win the handshake and MRUK keeps
+                // pulling frames steadily.
+                ICameraProvider provider = GetActiveCameraProvider();
+                provider?.StartCapture();
+                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: camera StartCapture took {sw.ElapsedMilliseconds} ms");
+                sw.Restart();
+                _depthCapture.StartDepthCapture();
+                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: DepthCapture.StartDepthCapture took {sw.ElapsedMilliseconds} ms");
+                sw.Restart();
+
+                if (!resuming)
+                {
+                    // Fresh scan: reset registry — stale AI detections from a previous
+                    // session/load are in a different anchor frame and must be discarded.
+                    _sceneObjectRegistry = new SceneObjectRegistry();
+                }
+                else
+                {
+                    _sceneObjectRegistry ??= new SceneObjectRegistry();
+                }
+                PopulateSceneObjectRegistry();
+                SubscribeToAnchorsChanged();
+
+                Logger.Info($"StartScanning — resuming={resuming}, integrationCount={_volumeIntegrator.IntegrationCount}");
+                ScanStarted?.Invoke();
+                if (_modules != null)
+                    foreach (var m in _modules) m.OnScanStarted();
+
+                Logger.Info($"StartScanning RETURNED — total wall-clock {swTotal.ElapsedMilliseconds} ms (includes 4 yielded frames between alloc steps and PCA start). " +
+                            "If you see MRUK/Vulkan errors here, the staging didn't actually yield — check the per-step gaps in this log block.");
             }
-
-            _keyframeCollector?.SetExportDirectory(
-                Path.Combine(_persistence.ActivePackageDirectory, "keyframes"));
-
-            float t = Time.time;
-            _lastIntegrationTime = t;
-            _lastMeshTime = t;
-
-            _cameraAvailable = false;
-
-            ICameraProvider provider = GetActiveCameraProvider();
-            provider?.StartCapture();
-            Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: camera StartCapture took {sw.ElapsedMilliseconds} ms");
-            sw.Restart();
-            _depthCapture.StartDepthCapture();
-            Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: DepthCapture.StartDepthCapture took {sw.ElapsedMilliseconds} ms");
-            sw.Restart();
-
-            if (!resuming)
+            catch
             {
-                // Fresh scan: reset registry — stale AI detections from a previous
-                // session/load are in a different anchor frame and must be discarded.
-                _sceneObjectRegistry = new SceneObjectRegistry();
+                // Reset the re-entry guard so the user can retry. Without
+                // this, a throw mid-warmup would leave IsScanning=true
+                // forever and every subsequent A-press would no-op.
+                IsScanning = false;
+                throw;
             }
-            else
-            {
-                _sceneObjectRegistry ??= new SceneObjectRegistry();
-            }
-            PopulateSceneObjectRegistry();
-            SubscribeToAnchorsChanged();
-
-            Logger.Info($"StartScanning — resuming={resuming}, integrationCount={_volumeIntegrator.IntegrationCount}");
-            ScanStarted?.Invoke();
-            if (_modules != null)
-                foreach (var m in _modules) m.OnScanStarted();
-
-            Logger.Info($"StartScanning RETURNED — total main-thread time {swTotal.ElapsedMilliseconds} ms. " +
-                        "If field reports describe a >5 s 'permanent hang' this is the upper " +
-                        "bound on the synchronous part; anything beyond that is fire-and-forget " +
-                        "(spatial anchor handshake) or compositor / OVR runtime giving up after " +
-                        "the long stall.");
         }
 
         /// <summary>
@@ -732,11 +698,18 @@ namespace Genesis.RoomScan
                 foreach (var m in _modules) m.OnScanStopped();
         }
 
-        /// <summary>Toggles between <see cref="StartScanning"/> and <see cref="StopScanning"/>.</summary>
+        /// <summary>
+        /// Toggles between <see cref="StartScanningAsync"/> and <see cref="StopScanning"/>.
+        /// The Start path is fire-and-forget here because this is a debug/dev API
+        /// (typically wired to a debug-menu button) and the small ~56 ms delay
+        /// before integration begins is not worth changing the toggle's signature
+        /// for. Production callers should await <see cref="StartScanningAsync"/>
+        /// directly so they can sequence UI feedback around the start.
+        /// </summary>
         public void ToggleScanning()
         {
             if (IsScanning) StopScanning();
-            else StartScanning();
+            else _ = StartScanningAsync();
         }
 
         /// <summary>True after <see cref="ReleaseScanResources"/> has been called. Cleared when scanning restarts.</summary>
@@ -746,7 +719,7 @@ namespace Genesis.RoomScan
         /// Frees heavy GPU resources (TSDF volumes, Surface Nets buffers, depth textures) to reclaim
         /// ~400-500 MB of GPU memory. Call after scanning + refinement is complete, before entering gameplay.
         /// The refined MeshRenderer stays alive for game-phase rendering.
-        /// Call <see cref="StartScanning"/> to re-allocate everything if a new scan is needed.
+        /// Call <see cref="StartScanningAsync"/> to re-allocate everything if a new scan is needed.
         /// </summary>
         public void ReleaseScanResources()
         {
@@ -786,7 +759,7 @@ namespace Genesis.RoomScan
         /// stalls and potential SynchronizationContext deadlocks on Quest/IL2CPP.
         /// GPU resources are disposed without immediate re-allocation to avoid
         /// Vulkan stalls when the GPU is still referencing the previous frame's buffers.
-        /// Re-initialization happens lazily on the next <see cref="StartScanning"/> or load.
+        /// Re-initialization happens lazily on the next <see cref="StartScanningAsync"/> or load.
         /// </summary>
         public void ClearAllDataAsync(Action onComplete = null)
         {

--- a/Runtime/Core/RoomScanner.cs
+++ b/Runtime/Core/RoomScanner.cs
@@ -457,11 +457,27 @@ namespace Genesis.RoomScan
             KeyframeRelocation = Matrix4x4.identity;
             _cachedUnwrap = null;
 
+            // Lazy GPU bring-up. Both calls are idempotent: ReallocateVolumes
+            // early-returns if RTs already exist, and EnsureInitialized
+            // early-returns if Surface Nets buffers are already up. This
+            // covers three cases uniformly:
+            //   1. First-ever scan in this session — heavy alloc happens here
+            //      (~150 MB TSDF + ~480 MB Surface Nets), NOT at scene load.
+            //   2. Resume after ReleaseScanResources — same thing.
+            //   3. Already-allocated mid-session — no-op.
+            // Reinitialize on the mesh side disposes/recreates so we use
+            // EnsureInitialized for the no-op-if-up branch and Reinitialize
+            // only after an explicit release.
             if (_scanResourcesReleased)
             {
                 _volumeIntegrator.ReallocateVolumes();
                 _meshExtractor.Reinitialize();
                 _scanResourcesReleased = false;
+            }
+            else
+            {
+                _volumeIntegrator.ReallocateVolumes();
+                _meshExtractor.EnsureInitialized();
             }
 
             // Resume within the same session: if we already have an active tmp

--- a/Runtime/Core/RoomScanner.cs
+++ b/Runtime/Core/RoomScanner.cs
@@ -487,15 +487,6 @@ namespace Genesis.RoomScan
                 KeyframeRelocation = Matrix4x4.identity;
                 _cachedUnwrap = null;
 
-                // ── Instrumentation ─────────────────────────────────────
-                // Per-step Stopwatch logs around every synchronous step so
-                // a future regression of the MRUK/Vulkan hang is easy to
-                // bisect. Will be removed in a follow-up commit once the
-                // staged-allocation fix is verified on device for both the
-                // first-scan and post-release-resume paths.
-                var swTotal = System.Diagnostics.Stopwatch.StartNew();
-                var sw = System.Diagnostics.Stopwatch.StartNew();
-
                 // ── Stage 1: GPU volume bring-up ────────────────────────
                 // Both calls are idempotent: ReallocateVolumes early-returns
                 // if RTs already exist; EnsureInitialized / Reinitialize
@@ -503,17 +494,7 @@ namespace Genesis.RoomScan
                 // _scanResourcesReleased branch uses Reinitialize because
                 // ReleaseScanResources explicitly disposes the mesh
                 // extractor and we need a true rebuild, not a no-op.
-                if (_scanResourcesReleased)
-                {
-                    _volumeIntegrator.ReallocateVolumes();
-                    Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: ReallocateVolumes (post-release) took {sw.ElapsedMilliseconds} ms");
-                }
-                else
-                {
-                    _volumeIntegrator.ReallocateVolumes();
-                    Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: ReallocateVolumes took {sw.ElapsedMilliseconds} ms");
-                }
-                sw.Restart();
+                _volumeIntegrator.ReallocateVolumes();
 
                 // Yield twice so the render thread can (a) actually commit
                 // the two 256³ 3D RT allocations to VRAM, and (b) run the
@@ -527,15 +508,12 @@ namespace Genesis.RoomScan
                 if (_scanResourcesReleased)
                 {
                     _meshExtractor.Reinitialize();
-                    Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: Mesh Reinitialize took {sw.ElapsedMilliseconds} ms");
                     _scanResourcesReleased = false;
                 }
                 else
                 {
                     _meshExtractor.EnsureInitialized();
-                    Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: EnsureInitialized took {sw.ElapsedMilliseconds} ms");
                 }
-                sw.Restart();
 
                 // Yield twice so the render thread can commit the ~480 MB
                 // ComputeBuffers + cell-table upload before PCA enables.
@@ -600,11 +578,7 @@ namespace Genesis.RoomScan
                         _keyframeCollector.ClearInMemory();
 
                     _persistence.CreateTmpPackage();
-                    Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: CreateTmpPackage took {sw.ElapsedMilliseconds} ms");
-                    sw.Restart();
                     _ = CreateScanAnchorAsync();
-                    Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: CreateScanAnchorAsync (fire-and-forget) launch took {sw.ElapsedMilliseconds} ms");
-                    sw.Restart();
                 }
 
                 _keyframeCollector?.SetExportDirectory(
@@ -624,11 +598,7 @@ namespace Genesis.RoomScan
                 // pulling frames steadily.
                 ICameraProvider provider = GetActiveCameraProvider();
                 provider?.StartCapture();
-                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: camera StartCapture took {sw.ElapsedMilliseconds} ms");
-                sw.Restart();
                 _depthCapture.StartDepthCapture();
-                Logger.Info($"StartScanning[t+{swTotal.ElapsedMilliseconds}ms]: DepthCapture.StartDepthCapture took {sw.ElapsedMilliseconds} ms");
-                sw.Restart();
 
                 if (!resuming)
                 {
@@ -647,9 +617,6 @@ namespace Genesis.RoomScan
                 ScanStarted?.Invoke();
                 if (_modules != null)
                     foreach (var m in _modules) m.OnScanStarted();
-
-                Logger.Info($"StartScanning RETURNED — total wall-clock {swTotal.ElapsedMilliseconds} ms (includes 4 yielded frames between alloc steps and PCA start). " +
-                            "If you see MRUK/Vulkan errors here, the staging didn't actually yield — check the per-step gaps in this log block.");
             }
             catch
             {

--- a/Runtime/Core/RoomScanner.cs
+++ b/Runtime/Core/RoomScanner.cs
@@ -1224,6 +1224,7 @@ namespace Genesis.RoomScan
             _refinedMesh.SetNormals(enhanced.Normals);
             _refinedMesh.SetUVs(0, enhanced.UVs);
             _refinedMesh.SetTriangles(enhanced.Indices, 0);
+            _refinedMesh.RecalculateBounds();
 
             EnsureRefinedRenderer();
             _refinedMeshFilter.mesh = _refinedMesh;
@@ -1262,6 +1263,7 @@ namespace Genesis.RoomScan
             _refinedMesh.SetUVs(0, result.UVs);
             _refinedMesh.SetTriangles(result.Indices, 0);
             _refinedMesh.RecalculateTangents();
+            _refinedMesh.RecalculateBounds();
 
             Logger.Info($"Refined mesh applied: " +
                 $"{result.Positions.Length} verts, {result.Indices.Length / 3} tris, " +
@@ -1425,6 +1427,11 @@ namespace Genesis.RoomScan
             _refinedMesh.SetNormals(unwrap.Normals);
             _refinedMesh.SetUVs(0, unwrap.UVs);
             _refinedMesh.SetTriangles(unwrap.Indices, 0);
+            // Without explicit bounds, Unity's frustum culling treats the
+            // mesh as a zero-size point at the local origin and the renderer
+            // pops in/out depending on view direction. SetTriangles does not
+            // recompute bounds when only positions/indices change.
+            _refinedMesh.RecalculateBounds();
             EnsureRefinedRenderer();
             _refinedMeshFilter.mesh = _refinedMesh;
         }
@@ -1818,6 +1825,7 @@ namespace Genesis.RoomScan
                     _refinedMesh.SetNormals(r.Normals);
                     _refinedMesh.SetUVs(0, r.UVs);
                     _refinedMesh.SetTriangles(r.Indices, 0);
+                    _refinedMesh.RecalculateBounds();
                     EnsureRefinedRenderer();
                     _refinedMeshFilter.mesh = _refinedMesh;
                 }

--- a/Runtime/Core/VolumeIntegrator.cs
+++ b/Runtime/Core/VolumeIntegrator.cs
@@ -249,7 +249,7 @@ namespace Genesis.RoomScan
         ///   <see cref="RebindKernelTextures"/>.</description></item>
         ///   <item><description><b>Already allocated</b>: no-op.</description></item>
         /// </list>
-        /// Called by <see cref="RoomScanner.StartScanning"/> and the heavy
+        /// Called by <see cref="RoomScanner.StartScanningAsync"/> and the heavy
         /// <c>RoomScanPersistence</c> save/full-load paths. The lightweight
         /// <c>LoadRefinedOnlyAsync</c> path intentionally skips this.
         /// </summary>

--- a/Runtime/Core/VolumeIntegrator.cs
+++ b/Runtime/Core/VolumeIntegrator.cs
@@ -257,7 +257,9 @@ namespace Genesis.RoomScan
         {
             if (_volume != null) return;
 
-            bool firstAlloc = (_clearKernel == null);
+            // ComputeKernelHelper is a struct — use its readonly Shader
+            // backing field as the "never initialized" sentinel.
+            bool firstAlloc = (_clearKernel.Shader == null);
 
             CreateVolume();
 
@@ -371,7 +373,7 @@ namespace Genesis.RoomScan
         /// </summary>
         public void Clear()
         {
-            if (_volume == null || _clearKernel == null) return;
+            if (_volume == null || _clearKernel.Shader == null) return;
             _clearKernel.Set(VolumeRWID, _volume);
             _clearKernel.Set(ColorVolumeRWID, _colorVolume);
             _clearKernel.DispatchFit(_volume);
@@ -457,7 +459,7 @@ namespace Genesis.RoomScan
         public void FreezeInView(Vector3 camPos, Quaternion camRot,
             Vector2 focalLen, Vector2 principalPt, Vector2 sensorRes, Vector2 currentRes)
         {
-            if (_volume == null || _freezeKernel == null)
+            if (_volume == null || _freezeKernel.Shader == null)
             {
                 Logger.Warning("FreezeInView called before GPU resources allocated; ignored.");
                 return;
@@ -475,7 +477,7 @@ namespace Genesis.RoomScan
         public void UnfreezeInView(Vector3 camPos, Quaternion camRot,
             Vector2 focalLen, Vector2 principalPt, Vector2 sensorRes, Vector2 currentRes)
         {
-            if (_volume == null || _unfreezeKernel == null)
+            if (_volume == null || _unfreezeKernel.Shader == null)
             {
                 Logger.Warning("UnfreezeInView called before GPU resources allocated; ignored.");
                 return;
@@ -608,7 +610,7 @@ namespace Genesis.RoomScan
             // ReallocateVolumes can land here. RoomScanner.StartScanning()
             // always calls ReallocateVolumes first, so this is just a
             // safety net.
-            if (_volume == null || _integrateKernel == null) return;
+            if (_volume == null || _integrateKernel.Shader == null) return;
             if (!_frustumReady) SetupFrustumVolume();
             if (!_frustumReady) return;
 

--- a/Runtime/Core/VolumeIntegrator.cs
+++ b/Runtime/Core/VolumeIntegrator.cs
@@ -153,12 +153,31 @@ namespace Genesis.RoomScan
         private void Awake()
         {
             Instance = this;
-            // Create GPU volumes in Awake so RoomScanPersistence.LoadAsync and other
-            // early callers never see Volume == null (Start order is not guaranteed).
-            CreateVolume();
+            // GPU resources allocate lazily on the first scan / save / full-load
+            // path via ReallocateVolumes(). The lightweight LoadRefinedOnlyAsync
+            // path (returning-player and editor-sim) never touches them, so a
+            // pure replay session avoids the ~150 MB TSDF+color RT footprint.
         }
 
         private void Start()
+        {
+            // Intentionally empty — see Awake().
+            //
+            // Historic note: kernel helpers + 3D RTs used to be constructed
+            // here unconditionally. They're now created on demand inside
+            // ReallocateVolumes(), which is called by:
+            //   * RoomScanner.StartScanning() (every scan begin)
+            //   * RoomScanPersistence.SaveToNewPackageAsync (defensive)
+            //   * RoomScanPersistence.LoadPackageAsync (full TSDF reload)
+        }
+
+        /// <summary>
+        /// Build all compute-kernel helpers and bind them to the current
+        /// <see cref="_volume"/> / <see cref="_colorVolume"/>. Idempotent —
+        /// the first <see cref="ReallocateVolumes"/> call constructs them;
+        /// subsequent allocations only need <see cref="RebindKernelTextures"/>.
+        /// </summary>
+        private void InitKernels()
         {
             _clearKernel = new ComputeKernelHelper(compute, "Clear");
             _clearKernel.Set(VolumeRWID, _volume);
@@ -187,12 +206,6 @@ namespace Genesis.RoomScan
             _dummyCamTex = new Texture2D(1, 1, TextureFormat.RGBA32, false);
             _dummyCamTex.SetPixel(0, 0, Color.black);
             _dummyCamTex.Apply(false, true);
-
-            SetShaderConstants();
-            Clear();
-
-            if (DepthCapture.Instance != null)
-                DepthCapture.Instance.SetVoxelParams(voxelDistance, voxelSize);
         }
 
         private void OnDestroy()
@@ -224,16 +237,42 @@ namespace Genesis.RoomScan
         public bool VolumesReleased => _volume == null;
 
         /// <summary>
-        /// Re-creates TSDF + color volumes after a prior <see cref="ReleaseVolumes"/> call.
+        /// Allocate (or re-allocate) TSDF + color volumes and bring kernels +
+        /// shader constants up to date. Idempotent — early-returns if volumes
+        /// already exist. Handles three scenarios:
+        /// <list type="bullet">
+        ///   <item><description><b>First-ever scan</b>: builds compute kernels
+        ///   from scratch (deferred from the old eager <c>Awake</c>/<c>Start</c>
+        ///   path), allocates RTs, sets globals.</description></item>
+        ///   <item><description><b>Resume after <see cref="ReleaseVolumes"/></b>:
+        ///   re-allocates RTs and rebinds existing kernels via
+        ///   <see cref="RebindKernelTextures"/>.</description></item>
+        ///   <item><description><b>Already allocated</b>: no-op.</description></item>
+        /// </list>
+        /// Called by <see cref="RoomScanner.StartScanning"/> and the heavy
+        /// <c>RoomScanPersistence</c> save/full-load paths. The lightweight
+        /// <c>LoadRefinedOnlyAsync</c> path intentionally skips this.
         /// </summary>
         public void ReallocateVolumes()
         {
             if (_volume != null) return;
+
+            bool firstAlloc = (_clearKernel == null);
+
             CreateVolume();
+
+            if (firstAlloc) InitKernels();
+            else            RebindKernelTextures();
+
             SetShaderConstants();
             Clear();
-            RebindKernelTextures();
-            Logger.Info("VolumeIntegrator: GPU volumes re-allocated");
+
+            if (DepthCapture.Instance != null)
+                DepthCapture.Instance.SetVoxelParams(voxelDistance, voxelSize);
+
+            Logger.Info(firstAlloc
+                ? "VolumeIntegrator: GPU resources allocated lazily on first scan/save/full-load."
+                : "VolumeIntegrator: GPU volumes re-allocated after release.");
         }
 
         private void RebindKernelTextures()
@@ -326,10 +365,13 @@ namespace Genesis.RoomScan
         }
 
         /// <summary>
-        /// Zeros the TSDF and color volumes on the GPU.
+        /// Zeros the TSDF and color volumes on the GPU. No-op if volumes
+        /// haven't been allocated yet (lazy alloc — see
+        /// <see cref="ReallocateVolumes"/>).
         /// </summary>
         public void Clear()
         {
+            if (_volume == null || _clearKernel == null) return;
             _clearKernel.Set(VolumeRWID, _volume);
             _clearKernel.Set(ColorVolumeRWID, _colorVolume);
             _clearKernel.DispatchFit(_volume);
@@ -415,6 +457,11 @@ namespace Genesis.RoomScan
         public void FreezeInView(Vector3 camPos, Quaternion camRot,
             Vector2 focalLen, Vector2 principalPt, Vector2 sensorRes, Vector2 currentRes)
         {
+            if (_volume == null || _freezeKernel == null)
+            {
+                Logger.Warning("FreezeInView called before GPU resources allocated; ignored.");
+                return;
+            }
             SetFrustumCameraUniforms(_freezeKernel, camPos, camRot,
                 focalLen, principalPt, sensorRes, currentRes);
             _freezeKernel.Set(VolumeRWID, _volume);
@@ -428,6 +475,11 @@ namespace Genesis.RoomScan
         public void UnfreezeInView(Vector3 camPos, Quaternion camRot,
             Vector2 focalLen, Vector2 principalPt, Vector2 sensorRes, Vector2 currentRes)
         {
+            if (_volume == null || _unfreezeKernel == null)
+            {
+                Logger.Warning("UnfreezeInView called before GPU resources allocated; ignored.");
+                return;
+            }
             SetFrustumCameraUniforms(_unfreezeKernel, camPos, camRot,
                 focalLen, principalPt, sensorRes, currentRes);
             _unfreezeKernel.Set(VolumeRWID, _volume);
@@ -552,6 +604,11 @@ namespace Genesis.RoomScan
         {
             var dc = DepthCapture.Instance;
             if (dc == null || !DepthCapture.DepthAvailable || dc.DepthTex == null) return;
+            // Defensive: with lazy GPU alloc a stray Integrate() before
+            // ReallocateVolumes can land here. RoomScanner.StartScanning()
+            // always calls ReallocateVolumes first, so this is just a
+            // safety net.
+            if (_volume == null || _integrateKernel == null) return;
             if (!_frustumReady) SetupFrustumVolume();
             if (!_frustumReady) return;
 

--- a/Runtime/Core/VolumeIntegrator.cs
+++ b/Runtime/Core/VolumeIntegrator.cs
@@ -261,13 +261,33 @@ namespace Genesis.RoomScan
             // backing field as the "never initialized" sentinel.
             bool firstAlloc = (_clearKernel.Shader == null);
 
+            // ── Instrumentation ─────────────────────────────────────────
+            // Field reports of "permanent hang on first scan press" need
+            // a finer breakdown than the wrapping StartScanning logs can
+            // give us. CreateVolume = two RenderTexture.Create on 256³
+            // 3D RTs = the most likely Vulkan stall point (descriptor
+            // pool drain). InitKernels = first-dispatch shader cache
+            // warm. Clear = first compute dispatch on the freshly
+            // allocated UAV-enabled 3D RT. Remove with the rest of the
+            // diagnostic logs once the warmup path is verified.
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+
             CreateVolume();
+            Logger.Info($"ReallocateVolumes: CreateVolume took {sw.ElapsedMilliseconds} ms (firstAlloc={firstAlloc})");
+            sw.Restart();
 
             if (firstAlloc) InitKernels();
             else            RebindKernelTextures();
+            Logger.Info($"ReallocateVolumes: {(firstAlloc ? "InitKernels" : "RebindKernelTextures")} took {sw.ElapsedMilliseconds} ms");
+            sw.Restart();
 
             SetShaderConstants();
+            Logger.Info($"ReallocateVolumes: SetShaderConstants took {sw.ElapsedMilliseconds} ms");
+            sw.Restart();
+
             Clear();
+            Logger.Info($"ReallocateVolumes: Clear (first compute dispatch on fresh RT) took {sw.ElapsedMilliseconds} ms");
+            sw.Restart();
 
             if (DepthCapture.Instance != null)
                 DepthCapture.Instance.SetVoxelParams(voxelDistance, voxelSize);

--- a/Runtime/Core/VolumeIntegrator.cs
+++ b/Runtime/Core/VolumeIntegrator.cs
@@ -261,33 +261,13 @@ namespace Genesis.RoomScan
             // backing field as the "never initialized" sentinel.
             bool firstAlloc = (_clearKernel.Shader == null);
 
-            // ── Instrumentation ─────────────────────────────────────────
-            // Field reports of "permanent hang on first scan press" need
-            // a finer breakdown than the wrapping StartScanning logs can
-            // give us. CreateVolume = two RenderTexture.Create on 256³
-            // 3D RTs = the most likely Vulkan stall point (descriptor
-            // pool drain). InitKernels = first-dispatch shader cache
-            // warm. Clear = first compute dispatch on the freshly
-            // allocated UAV-enabled 3D RT. Remove with the rest of the
-            // diagnostic logs once the warmup path is verified.
-            var sw = System.Diagnostics.Stopwatch.StartNew();
-
             CreateVolume();
-            Logger.Info($"ReallocateVolumes: CreateVolume took {sw.ElapsedMilliseconds} ms (firstAlloc={firstAlloc})");
-            sw.Restart();
 
             if (firstAlloc) InitKernels();
             else            RebindKernelTextures();
-            Logger.Info($"ReallocateVolumes: {(firstAlloc ? "InitKernels" : "RebindKernelTextures")} took {sw.ElapsedMilliseconds} ms");
-            sw.Restart();
 
             SetShaderConstants();
-            Logger.Info($"ReallocateVolumes: SetShaderConstants took {sw.ElapsedMilliseconds} ms");
-            sw.Restart();
-
             Clear();
-            Logger.Info($"ReallocateVolumes: Clear (first compute dispatch on fresh RT) took {sw.ElapsedMilliseconds} ms");
-            sw.Restart();
 
             if (DepthCapture.Instance != null)
                 DepthCapture.Instance.SetVoxelParams(voxelDistance, voxelSize);

--- a/Runtime/Utils/RoomScanSession.cs
+++ b/Runtime/Utils/RoomScanSession.cs
@@ -54,11 +54,25 @@ namespace Genesis.RoomScan
                 ProgressUpdated?.Invoke(_scanner.CurrentProgress);
         }
 
-        /// <summary>Begins a new scan session. The room mesh builds in real-time as the user looks around.</summary>
-        public void StartScan()
+        /// <summary>
+        /// Begins a new scan session. The room mesh builds in real-time as
+        /// the user looks around. Async because <see cref="RoomScanner.StartScanningAsync"/>
+        /// stages the heavy GPU bring-up across a few frames before
+        /// enabling the passthrough camera (otherwise the PCA / MRUK
+        /// handshake races our compute dispatches and the compositor
+        /// freezes — see that method's docs for the full story). Total
+        /// wall-clock from await to first integrated frame is ~56 ms,
+        /// imperceptible to the user but worth awaiting so callers can
+        /// sequence UI feedback ("Scanning…") right after.
+        /// </summary>
+        public Task StartScanAsync()
         {
-            if (_scanner == null) { Logger.Error("RoomScanSession: RoomScanner not found"); return; }
-            _scanner.StartScanning();
+            if (_scanner == null)
+            {
+                Logger.Error("RoomScanSession: RoomScanner not found");
+                return Task.CompletedTask;
+            }
+            return _scanner.StartScanningAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

`VolumeIntegrator` and `MeshExtractor` used to allocate their full GPU footprint eagerly in `Awake`/`Start`, the moment the scan rig entered the scene:

| Component | Eager allocation | Cost (default 256³ grid) |
|---|---|---|
| `VolumeIntegrator.Awake` | TSDF (R8G8_SNorm) + color (RGBA8) 3D RTs | ~150 MB |
| `VolumeIntegrator.Start` | 6 `ComputeKernelHelper`s + coverage counter buffer + dummy cam tex + `Clear()` dispatch | small, but obligatory |
| `MeshExtractor.Start` | `GPUSurfaceNets` buffers + `GPUMeshRenderer` | ~480 MB (8% vertex budget) |
| **Total** | | **~600 MB GPU** |

The lightweight `LoadRefinedOnlyAsync` path — used by every host app that loads a previously-saved scan and skips straight to gameplay — never touches any of these. Only `StartScanning`, `SaveToNewPackageAsync`, and the full-reconstruction `LoadPackageAsync` need them. The eager allocation was wasted memory on every replay-only cold load.

## What this PR changes

- **`VolumeIntegrator.Awake/Start`** are now no-ops. `ReallocateVolumes()` is the single idempotent entry point and handles three cases uniformly:
  - first-ever allocation (constructs kernel helpers via new private `InitKernels()`)
  - post-`ReleaseVolumes` resume (rebinds existing kernels via the existing `RebindKernelTextures`)
  - already-allocated (early return)
- **`MeshExtractor.Start`** keeps the device-trace pipeline log (so RP / stereo / material state is still visible at scene load) but no longer calls `Init()`. New public `EnsureInitialized()` is the idempotent lazy entry.
- **`RoomScanner.StartScanning`** calls `ReallocateVolumes` + `EnsureInitialized` unconditionally on every call. Both are idempotent so the heavy GPU bill only materialises on the first scan begin in a session, not on cold load.
- **`RoomScanPersistence.SaveToNewPackageAsync`** and **`LoadPackageAsync`** self-heal via `ReallocateVolumes` / `EnsureInitialized` so callers (debug menu, test runners, external integrations) don't have to know about the lazy contract.
- **Defensive null guards** on `VolumeIntegrator.Clear` / `FreezeInView` / `UnfreezeInView` / `Integrate` so a stray dispatch before allocation logs a warning instead of NRE-ing.

## Net impact

A host-app session that loads a saved scan and goes straight into gameplay **never pays the ~600 MB GPU bill until (and unless) the user explicitly starts a new scan**. For developers using the debug menu's full TSDF reload path, behaviour is unchanged — `LoadPackageAsync` calls `ReallocateVolumes` defensively before reading `Volume`.

## Test plan

- [ ] **Replay only**: load via `RoomScanSession.LoadAsync(packageId)` — verify console shows `MeshExtractor Start (Surface Nets buffers deferred)` and **no** `[GPUSurfaceNets] Allocated buffers ... totalGPU=483MB` line.
- [ ] **Fresh scan**: call `StartScanning()` from a blank session — verify the `VolumeIntegrator: GPU resources allocated lazily on first scan/save/full-load` and `GPU Surface Nets initialized lazily` logs fire exactly once, then voxels integrate normally.
- [ ] **Resume after `ReleaseScanResources`**: scan, finalize (which releases), `StartScanning` again — verify the `VolumeIntegrator: GPU volumes re-allocated after release` log fires and a second scan completes.
- [ ] **Full TSDF reload via debug menu** (`LoadPackageAsync`): from a session that never scanned, load a package with `scan.bin` — verify `ReallocateVolumes` self-heals and the volume populates from disk.
- [ ] **Freeze/Unfreeze before alloc** (paranoia): call `FreezeInView` before `StartScanning` — verify it logs the warning and returns instead of NRE-ing.


Made with [Cursor](https://cursor.com)