### PR TITLE
perf: defer ~600 MB scan GPU allocations until first scan/save/full-load

### DIFF
--- a/ALGORITHM.md
+++ b/ALGORITHM.md
@@ -494,7 +494,7 @@ Per mesh extraction cycle, `UpdatePlateauDetection` tracks:
 ## 12b. Depth Subsystem Gating
 
 `DepthCapture` manages the `AROcclusionManager` lifecycle to avoid unnecessary GPU work:
-- **`StartDepthCapture()`**: Enables `AROcclusionManager`, subscribes to `frameReceived`. Called by `RoomScanner.StartScanning()`.
+- **`StartDepthCapture()`**: Enables `AROcclusionManager`, subscribes to `frameReceived`. Called by `RoomScanner.StartScanningAsync()`.
 - **`StopDepthCapture()`**: Unsubscribes, disables `AROcclusionManager` (calls `subsystem.Stop()` — shuts down depth sensor and neural inference on Quest). Called by `RoomScanner.StopScanning()`.
 - **`_permissionReady`**: Set once after USE_SCENE permission is confirmed and subsystem verified.
 - **`_captureActive`**: Persists across app pause/resume. `OnApplicationPause(false)` only re-enables the subsystem if `_captureActive` was true.

--- a/Editor/RoomScanSetupWizard.cs
+++ b/Editor/RoomScanSetupWizard.cs
@@ -780,7 +780,45 @@ namespace Genesis.RoomScan.Editor
                     Undo.RegisterCreatedObjectUndo(root, "Create RoomScan");
                 }
             }
+
+            EnsureRoomScanIdentityTransform(root);
             return root;
+        }
+
+        // The RoomScan GameObject MUST have an identity local transform.
+        // RoomScanner spawns a child "RefinedMeshRenderer" whose mesh
+        // vertices are pre-baked into world-space coordinates by
+        // RoomScanPersistence.RelocateVertices, and RefinedMesh.shader
+        // bypasses the object-to-world matrix (uses posWS directly). Unity
+        // still uses localToWorldMatrix for frustum-cull bounds, so any
+        // non-identity scale on this GameObject silently shrinks (or moves)
+        // the culling box away from the actual geometry — the rendered mesh
+        // then "disappears" from most viewing angles unless the camera
+        // frustum happens to clip the displaced bounds. Reset defensively.
+        static void EnsureRoomScanIdentityTransform(GameObject root)
+        {
+            if (root == null) return;
+            var t = root.transform;
+
+            bool wrongScale = t.localScale != Vector3.one;
+            bool wrongPos = t.localPosition != Vector3.zero;
+            bool wrongRot = t.localRotation != Quaternion.identity;
+            if (!wrongScale && !wrongPos && !wrongRot) return;
+
+            Undo.RecordObject(t, "Reset RoomScan transform to identity");
+            t.localScale = Vector3.one;
+            t.localPosition = Vector3.zero;
+            t.localRotation = Quaternion.identity;
+            EditorUtility.SetDirty(root);
+
+            Debug.LogWarning(
+                $"[RoomScanSetupWizard] Reset '{root.name}' transform to identity " +
+                $"(wrongScale={wrongScale}, wrongPos={wrongPos}, wrongRot={wrongRot}). " +
+                "RoomScanner's refined-mesh renderer hosts pre-baked world-space " +
+                "vertices and bypasses object-to-world in its shader; any non-identity " +
+                "parent transform breaks frustum-cull bounds and the mesh disappears " +
+                "from most viewing angles. Don't put world-space UI panels (UIDocument) " +
+                "directly on RoomScan — keep them on their own child GameObject.");
         }
 
         void FixCoreComponents()
@@ -907,7 +945,7 @@ namespace Genesis.RoomScan.Editor
             StatusRowOptional("PassthroughCameraProvider", hasPCAProvider);
             StatusRowOptional("TextureRefinement (atlas baking)", hasRefinement);
             StatusRowOptional("RoomUnderstanding (MRUK bridge)", hasRoomUnderstanding);
-            StatusRowOptional("RoomScanSession (game-dev async API: StartScan / FinalizeScanAsync / LoadLatestAsync)",
+            StatusRowOptional("RoomScanSession (game-dev async API: StartScanAsync / FinalizeScanAsync / LoadLatestAsync)",
                               _session != null);
 
             if (hasRefinement)
@@ -1155,7 +1193,7 @@ namespace Genesis.RoomScan.Editor
             if (root.GetComponent<RoomUnderstanding>() == null)
                 Undo.AddComponent<RoomUnderstanding>(root);
 
-            // RoomScanSession: public game-dev facade (StartScan / FinalizeScanAsync /
+            // RoomScanSession: public game-dev facade (StartScanAsync / FinalizeScanAsync /
             // LoadLatestAsync / HasSavedScan / ProgressUpdated). Without it,
             // game code that follows the documented public-API path cannot
             // find RoomScanSession.Instance and bails.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Both optional dependencies can be combined. The `Genesis.RoomScan.AIDetection` a
 
 ### Scanning
 
-Call `RoomScanner.Instance.StartScanning()` to begin (or use the debug menu). As you look around:
+Call `await RoomScanner.Instance.StartScanningAsync()` to begin (or use the debug menu). As you look around:
 
 1. **Depth integration**: Each depth frame is fused into the TSDF volume with color from the passthrough camera
 2. **Mesh extraction**: GPU Surface Nets extracts a mesh from the volume every few frames (after a minimum number of integrations)
@@ -487,7 +487,11 @@ if (session.HasSavedScan)
     await session.ClearAllScansAsync();
 
 // 2. Begin scanning. The room mesh builds in real-time as the user looks around.
-session.StartScan();
+//    Awaitable: StartScanAsync stages the heavy GPU bring-up across ~4 yielded
+//    frames (~56 ms total) before enabling the passthrough camera, so PCA's
+//    hardware-buffer handshake doesn't race our compute dispatches and tank
+//    MRUK/Vulkan. Below human-perception threshold for "press registered".
+await session.StartScanAsync();
 session.ProgressUpdated += p => progressBar.value = p.OverallProgress;
 
 // 3. As the user sweeps the room, paint visible chunks as "done":
@@ -517,7 +521,7 @@ if (session.HasSavedScan)
 
 `FinalizeScanAsync()` handles everything: stop scanning → texture refinement → save to disk → release GPU resources. The scan is also persisted as a self-contained package under `Application.persistentDataPath/RoomScans/pkg_<timestamp>/` with its own `OVRSpatialAnchor` for cross-session relocation.
 
-> **Why explicit permission gating matters.** PCA's own `OnEnable` waits for the user's permission decision in a coroutine, so the scan eventually transitions to RGB mode after the user accepts. But during the wait, `RoomScanner.StartScanning()` has already kicked off integration in degraded depth-only mode, and there's no place for game UI to show an "asking for permission" state. Calling `await session.RequestCameraPermissionAsync()` *before* `StartScan()` lets you surface a deterministic UI state and only kick off integration once you actually have the camera.
+> **Why explicit permission gating matters.** PCA's own `OnEnable` waits for the user's permission decision in a coroutine, so the scan eventually transitions to RGB mode after the user accepts. But during the wait, `RoomScanner.StartScanningAsync()` has already kicked off integration in degraded depth-only mode, and there's no place for game UI to show an "asking for permission" state. Calling `await session.RequestCameraPermissionAsync()` *before* `StartScanAsync()` lets you surface a deterministic UI state and only kick off integration once you actually have the camera.
 
 > **Why `ClearAllScansAsync` and not save-then-purge.** `ClearAllScansAsync` deliberately wipes only saved packages (`pkg_*/` and `manifest.json`), never the active `_tmp/` working directory — that one is owned by `StartScan` / `FinalizeScanAsync`'s lifecycle. Safe to call at any point: if nothing is saved it returns immediately. The trade-off is that a finalize crash after a `ClearAllScansAsync` loses the previous scan; if your game wants the old scan to outlive a finalize failure, save first and purge after.
 
@@ -526,7 +530,7 @@ if (session.HasSavedScan)
 For developers who want finer control, the underlying APIs are:
 
 ```
-1. Scan Phase:    StartScanning() → user looks around → StopScanning()
+1. Scan Phase:    await StartScanningAsync() → user looks around → StopScanning()
 2. Refine:        StartTextureRefinement() → wait for RefinedMeshReady event
 3. Transition:    ReleaseScanResources() → frees ~400-500 MB GPU memory
 4. Game Phase:    Render with standard MeshRenderer (1 draw call, baked texture)
@@ -593,7 +597,7 @@ scanner.ReleaseScanResources();
 // Vertex/Wireframe/Triplanar modes become unavailable (IsModeAvailable returns false)
 
 // To scan again later (re-allocates everything):
-scanner.StartScanning();
+await scanner.StartScanningAsync();
 ```
 
 #### Monitoring Scan Progress
@@ -644,7 +648,7 @@ Everything a game needs lives on one component. `[RequireComponent(typeof(RoomSc
 1. Add QuestRoomScan to your `Packages/manifest.json` (see [Installation](#installation)).
 2. Open **`RoomScan > Setup Scene`** and click **`Apply Game-Ready Setup`**. Re-click after the build-target / domain reload to finish.
 3. Build to Quest 3 (or attach Quest Link).
-4. Game code: `await RoomScanSession.Instance.RequestCameraPermissionAsync();` then `RoomScanSession.Instance.StartScan();`.
+4. Game code: `await RoomScanSession.Instance.RequestCameraPermissionAsync();` then `await RoomScanSession.Instance.StartScanAsync();`.
 5. Bind a controller button to `FreezeInView` and another to `UnfreezeInView` (the QRS DebugMenu uses Y/B + X/A by default).
 6. When the user commits: `var result = await RoomScanSession.Instance.FinalizeScanAsync();` → use `result.Mesh` + `result.Atlas` to render with a standard `MeshRenderer`.
 7. On subsequent launches: `if (session.HasSavedScan) await session.LoadLatestAsync();` — skip scanning entirely.

--- a/Runtime/Core/MeshExtractor.cs
+++ b/Runtime/Core/MeshExtractor.cs
@@ -69,12 +69,31 @@ namespace Genesis.RoomScan
             if (surfaceNetsCompute == null)
                 throw new Exception("[RoomScan] surfaceNetsCompute not assigned on MeshExtractor");
 
+            // GPU Surface Nets buffers (~480 MB at the default 256³ voxel grid)
+            // are allocated lazily — first scan via RoomScanner.StartScanning,
+            // or full-load via RoomScanPersistence.LoadPackageAsync. Pure
+            // refined-mesh-only replay paths never trigger this. Keep the
+            // pipeline log here so device traces still show RP/stereo/material
+            // state at scene load, but defer the heavy Init().
             var rpAsset = GraphicsSettings.currentRenderPipeline;
-            Logger.Info($"MeshExtractor Start: mat={scanMeshMaterial?.name ?? "NULL"}, " +
+            Logger.Info($"MeshExtractor Start (Surface Nets buffers deferred): " +
+                $"mat={scanMeshMaterial?.name ?? "NULL"}, " +
                 $"shader={scanMeshMaterial?.shader?.name ?? "NULL"}, " +
                 $"rp={rpAsset?.name ?? "NULL"}, " +
                 $"stereoMode={UnityEngine.XR.XRSettings.stereoRenderingMode}");
+        }
 
+        /// <summary>
+        /// Lazy initializer. Brings up GPU Surface Nets buffers + the renderer
+        /// component if they aren't already up. Idempotent. Existing callers
+        /// (<see cref="Reinitialize"/>, <see cref="RoomScanner"/>'s update loop
+        /// guard, the Start of every scan) all funnel through here so the
+        /// allocation cost only appears when a scan or full reload actually
+        /// needs it.
+        /// </summary>
+        public void EnsureInitialized()
+        {
+            if (_gpuSurfaceNets != null) return;
             Init();
         }
 
@@ -98,13 +117,14 @@ namespace Genesis.RoomScan
                 ConvergenceThreshold = convergenceThreshold,
                 TemporalDeadzone = temporalDeadzone
             };
+
             _gpuSurfaceNets.EnsureBuffers(_volume.VoxelCount, gpuVertexBudgetPercent);
 
             _gpuRenderer = gameObject.AddComponent<GPUMeshRenderer>();
             _gpuRenderer.GpuMeshMaterial = scanMeshMaterial;
             _gpuRenderer.Initialize(_gpuSurfaceNets, _gpuSurfaceNets.GetVolumeBounds(_volume.VoxelSize));
 
-            Logger.Info($"GPU Surface Nets initialized: voxels={_volume.VoxelCount}, " +
+            Logger.Info($"GPU Surface Nets initialized lazily: voxels={_volume.VoxelCount}, " +
                       $"voxSize={_volume.VoxelSize}");
         }
 

--- a/Runtime/Core/RoomScanPersistence.cs
+++ b/Runtime/Core/RoomScanPersistence.cs
@@ -225,10 +225,24 @@ namespace Genesis.RoomScan
         public async Task<bool> SaveToNewPackageAsync()
         {
             var vi = VolumeIntegrator.Instance;
-            if (vi == null || vi.Volume == null)
+            if (vi == null)
             {
-                Logger.Warning("Cannot save, no volume");
+                Logger.Warning("Cannot save, VolumeIntegrator instance missing");
                 return false;
+            }
+            // Defensive: if a caller invokes Save without ever StartScanning
+            // (programmatic snapshot, test runner, etc.) the volume RTs will
+            // be null because of lazy alloc. ReallocateVolumes is idempotent.
+            // We don't fabricate scan data — if the volume is empty the saved
+            // payload will reflect that.
+            if (vi.Volume == null)
+            {
+                vi.ReallocateVolumes();
+                if (vi.Volume == null)
+                {
+                    Logger.Warning("Cannot save, ReallocateVolumes did not produce a Volume RT");
+                    return false;
+                }
             }
             if (IsSaving) { Logger.Warning("Save already in progress"); return false; }
 
@@ -730,6 +744,10 @@ namespace Genesis.RoomScan
                 mesh.SetUVs(0, displayData.UVs);
                 mesh.SetTriangles(displayData.Indices, 0);
                 mesh.RecalculateTangents();
+                // Frustum culling needs real bounds; without this the mesh
+                // is treated as a zero-size point at the local origin and
+                // pops in/out depending on view direction.
+                mesh.RecalculateBounds();
 
                 scanner.ApplyRefinedTexture(atlasTex, mesh, normalTex);
                 Logger.Info($"Refined atlas loaded ({meshData.AtlasWidth}x{meshData.AtlasHeight})" +
@@ -814,9 +832,21 @@ namespace Genesis.RoomScan
 
             var vi = VolumeIntegrator.Instance;
             var cm = MeshExtractor.Instance;
-            if (vi == null || vi.Volume == null)
+            if (vi == null)
             {
-                Logger.Warning("Cannot load, no volume");
+                Logger.Warning("Cannot load, VolumeIntegrator instance missing");
+                return false;
+            }
+            // Full-load path needs the GPU TSDF volume to receive the saved
+            // bytes. With lazy alloc the volume may not exist yet (e.g. user
+            // skipped past startup straight into "load saved scan for
+            // re-editing" via the debug menu). Bring it up on demand —
+            // idempotent if already allocated.
+            if (vi.Volume == null) vi.ReallocateVolumes();
+            if (cm != null) cm.EnsureInitialized();
+            if (vi.Volume == null)
+            {
+                Logger.Warning("Cannot load, ReallocateVolumes did not produce a Volume RT");
                 return false;
             }
             if (IsLoading) { Logger.Warning("Load already in progress"); return false; }

--- a/Runtime/Core/RoomScanner.cs
+++ b/Runtime/Core/RoomScanner.cs
@@ -34,7 +34,7 @@ namespace Genesis.RoomScan
     /// <summary>High-level phase of the scanning session.</summary>
     public enum ScanPhase
     {
-        /// <summary>Before <see cref="RoomScanner.StartScanning"/> is called.</summary>
+        /// <summary>Before <see cref="RoomScanner.StartScanningAsync"/> is called.</summary>
         NotStarted,
         /// <summary>New geometry appearing rapidly — early scan.</summary>
         Discovering,
@@ -449,107 +449,183 @@ namespace Genesis.RoomScan
         /// <summary>
         /// Begins depth integration and mesh extraction. Resets relocation state,
         /// clears in-memory keyframes, and starts the active camera provider.
+        ///
+        /// <para>
+        /// <b>Async by necessity, not by API preference.</b> The lazy GPU
+        /// bring-up (~150 MB TSDF + ~480 MB Surface Nets) and the
+        /// passthrough-camera handshake (PCA → MRUK) are both heavy work
+        /// for the render thread, and if they land in the same Unity frame
+        /// PCA's hardware-buffer-queue handshake loses the race against
+        /// our compute dispatches: MRUK then spams "Hardware buffer queue
+        /// is empty", Vulkan submit corrupts with
+        /// VK_ERROR_INITIALIZATION_FAILED, and the compositor never
+        /// recovers (perceived as a permanent hang on the user's first
+        /// A-press). The fix is to do the GPU allocations + first
+        /// dispatches first, yield twice between each step so the render
+        /// thread commits the new resources across separate frames, and
+        /// only then enable PCA + AROcclusionManager. Total wall-clock
+        /// cost on a Quest 3 is ~56 ms (4 frames at 72 fps) — below the
+        /// "press registered" threshold of human perception.
+        /// </para>
+        ///
+        /// <para>
+        /// Eager allocation in <c>Awake</c>/<c>Start</c> avoided the bug
+        /// because the render thread had committed all VRAM and run the
+        /// first dispatches across multiple uneventful boot-splash frames
+        /// before the user could ever press A. The lazy-alloc landing
+        /// regressed that without realising the timing was load-bearing.
+        /// We keep lazy alloc (so the load-existing-scan path doesn't pay
+        /// the 600 MB cost) and add the inline staging instead.
+        /// </para>
         /// </summary>
-        public void StartScanning()
+        public async Task StartScanningAsync()
         {
             if (IsScanning) return;
             IsScanning = true;
-            KeyframeRelocation = Matrix4x4.identity;
-            _cachedUnwrap = null;
-
-            if (_scanResourcesReleased)
+            try
             {
-                _volumeIntegrator.ReallocateVolumes();
-                _meshExtractor.Reinitialize();
-                _scanResourcesReleased = false;
-            }
-
-            // Resume within the same session: if we already have an active tmp
-            // package with scan data, keep it instead of nuking everything.
-            bool resuming = _persistence != null
-                && _persistence.ActivePackageId == RoomScanPersistence.TmpPkgId
-                && _volumeIntegrator.IntegrationCount > 0;
-
-            if (!resuming)
-            {
-                _prevVertexCount = 0;
-                _stableVertexCycles = 0;
-                _stableColorCycles = 0;
-                _prevColorCoverage = 0f;
-                _stabilizedTime = 0f;
-
-                // Invalidate any previously loaded / refined output. Without
-                // this, a Begin() that follows a LoadRefinedOnlyAsync (or a
-                // prior in-session refinement) leaves HasRefinedTexture=true
-                // and the old _refinedMesh visible, which (a) keeps the stale
-                // mesh on screen instead of switching to live vertex preview
-                // and (b) makes RoomScanSession.FinalizeScanAsync skip the
-                // "if (!HasRefinedTexture) StartTextureRefinement()" gate, so
-                // the new TSDF gets saved but no fresh refined_mesh.bin is
-                // ever written. This is the same per-state-reset that
-                // ClearAllDataAsync does, just narrowed to the things a fresh
-                // scan must invalidate (volumes are already re-alloc'd above).
-                HasRefinedTexture = false;
-                HasHQRefinedTexture = false;
-                HasEnhancedMesh = false;
-                LastRefinedResult = null;
-                LastSimplifiedResult = null;
+                KeyframeRelocation = Matrix4x4.identity;
                 _cachedUnwrap = null;
-                _refinedMesh = null;
-                if (_normalMapTexture != null)
+
+                // ── Stage 1: GPU volume bring-up ────────────────────────
+                // Both calls are idempotent: ReallocateVolumes early-returns
+                // if RTs already exist; EnsureInitialized / Reinitialize
+                // early-return for the same reason on the mesh side. The
+                // _scanResourcesReleased branch uses Reinitialize because
+                // ReleaseScanResources explicitly disposes the mesh
+                // extractor and we need a true rebuild, not a no-op.
+                _volumeIntegrator.ReallocateVolumes();
+
+                // Yield twice so the render thread can (a) actually commit
+                // the two 256³ 3D RT allocations to VRAM, and (b) run the
+                // first Clear compute dispatch. One yield is "next frame";
+                // two yields gives the compositor a clean frame in between
+                // before the much bigger Surface Nets alloc lands.
+                await Task.Yield();
+                await Task.Yield();
+
+                // ── Stage 2: Surface Nets mesh extractor ────────────────
+                if (_scanResourcesReleased)
                 {
-                    Destroy(_normalMapTexture);
-                    _normalMapTexture = null;
+                    _meshExtractor.Reinitialize();
+                    _scanResourcesReleased = false;
                 }
-                _gsplatProvider?.ClearSplat();
-                _gsplatProvider?.ResetSplatTransform();
-                _downloadedPlyData = null;
+                else
+                {
+                    _meshExtractor.EnsureInitialized();
+                }
 
-                // Switch render mode off Refined/HQRefined/Splat back to the
-                // live in-progress preview. Done after the HasRefined* flags
-                // are cleared so IsModeAvailable() reports the new state
-                // correctly and the renderer toggles in ApplyRenderMode pick
-                // up Vertex as the right visible mode.
-                SetRenderMode(ScanRenderMode.Vertex);
+                // Yield twice so the render thread can commit the ~480 MB
+                // ComputeBuffers + cell-table upload before PCA enables.
+                // This is the critical pair — without it, PCA's native
+                // OnEnable lands in the same frame as the first Surface
+                // Nets dispatch and the MRUK fence handshake fails.
+                await Task.Yield();
+                await Task.Yield();
 
-                if (_persistence != null) _persistence.ClearActivePackage();
-                if (_keyframeCollector != null)
-                    _keyframeCollector.ClearInMemory();
+                // ── Stage 3: persistence + per-scan invalidation ────────
+                // Resume within the same session: if we already have an
+                // active tmp package with scan data, keep it instead of
+                // nuking everything.
+                bool resuming = _persistence != null
+                    && _persistence.ActivePackageId == RoomScanPersistence.TmpPkgId
+                    && _volumeIntegrator.IntegrationCount > 0;
 
-                _persistence.CreateTmpPackage();
-                _ = CreateScanAnchorAsync();
+                if (!resuming)
+                {
+                    _prevVertexCount = 0;
+                    _stableVertexCycles = 0;
+                    _stableColorCycles = 0;
+                    _prevColorCoverage = 0f;
+                    _stabilizedTime = 0f;
+
+                    // Invalidate any previously loaded / refined output. Without
+                    // this, a Begin() that follows a LoadRefinedOnlyAsync (or a
+                    // prior in-session refinement) leaves HasRefinedTexture=true
+                    // and the old _refinedMesh visible, which (a) keeps the stale
+                    // mesh on screen instead of switching to live vertex preview
+                    // and (b) makes RoomScanSession.FinalizeScanAsync skip the
+                    // "if (!HasRefinedTexture) StartTextureRefinement()" gate, so
+                    // the new TSDF gets saved but no fresh refined_mesh.bin is
+                    // ever written. This is the same per-state-reset that
+                    // ClearAllDataAsync does, just narrowed to the things a fresh
+                    // scan must invalidate (volumes are already re-alloc'd above).
+                    HasRefinedTexture = false;
+                    HasHQRefinedTexture = false;
+                    HasEnhancedMesh = false;
+                    LastRefinedResult = null;
+                    LastSimplifiedResult = null;
+                    _cachedUnwrap = null;
+                    _refinedMesh = null;
+                    if (_normalMapTexture != null)
+                    {
+                        Destroy(_normalMapTexture);
+                        _normalMapTexture = null;
+                    }
+                    _gsplatProvider?.ClearSplat();
+                    _gsplatProvider?.ResetSplatTransform();
+                    _downloadedPlyData = null;
+
+                    // Switch render mode off Refined/HQRefined/Splat back to the
+                    // live in-progress preview. Done after the HasRefined* flags
+                    // are cleared so IsModeAvailable() reports the new state
+                    // correctly and the renderer toggles in ApplyRenderMode pick
+                    // up Vertex as the right visible mode.
+                    SetRenderMode(ScanRenderMode.Vertex);
+
+                    if (_persistence != null) _persistence.ClearActivePackage();
+                    if (_keyframeCollector != null)
+                        _keyframeCollector.ClearInMemory();
+
+                    _persistence.CreateTmpPackage();
+                    _ = CreateScanAnchorAsync();
+                }
+
+                _keyframeCollector?.SetExportDirectory(
+                    Path.Combine(_persistence.ActivePackageDirectory, "keyframes"));
+
+                float t = Time.time;
+                _lastIntegrationTime = t;
+                _lastMeshTime = t;
+
+                _cameraAvailable = false;
+
+                // ── Stage 4: camera + depth (now safe) ──────────────────
+                // PCA's native OnEnable handshakes with MRUK to grab the
+                // passthrough hardware buffer queue. By this point the
+                // GPU resources are committed and the render-thread queue
+                // is clean, so PCA can win the handshake and MRUK keeps
+                // pulling frames steadily.
+                ICameraProvider provider = GetActiveCameraProvider();
+                provider?.StartCapture();
+                _depthCapture.StartDepthCapture();
+
+                if (!resuming)
+                {
+                    // Fresh scan: reset registry — stale AI detections from a previous
+                    // session/load are in a different anchor frame and must be discarded.
+                    _sceneObjectRegistry = new SceneObjectRegistry();
+                }
+                else
+                {
+                    _sceneObjectRegistry ??= new SceneObjectRegistry();
+                }
+                PopulateSceneObjectRegistry();
+                SubscribeToAnchorsChanged();
+
+                Logger.Info($"StartScanning — resuming={resuming}, integrationCount={_volumeIntegrator.IntegrationCount}");
+                ScanStarted?.Invoke();
+                if (_modules != null)
+                    foreach (var m in _modules) m.OnScanStarted();
             }
-
-            _keyframeCollector?.SetExportDirectory(
-                Path.Combine(_persistence.ActivePackageDirectory, "keyframes"));
-
-            float t = Time.time;
-            _lastIntegrationTime = t;
-            _lastMeshTime = t;
-
-            _cameraAvailable = false;
-
-            ICameraProvider provider = GetActiveCameraProvider();
-            provider?.StartCapture();
-            _depthCapture.StartDepthCapture();
-
-            if (!resuming)
+            catch
             {
-                // Fresh scan: reset registry — stale AI detections from a previous
-                // session/load are in a different anchor frame and must be discarded.
-                _sceneObjectRegistry = new SceneObjectRegistry();
+                // Reset the re-entry guard so the user can retry. Without
+                // this, a throw mid-warmup would leave IsScanning=true
+                // forever and every subsequent A-press would no-op.
+                IsScanning = false;
+                throw;
             }
-            else
-            {
-                _sceneObjectRegistry ??= new SceneObjectRegistry();
-            }
-            PopulateSceneObjectRegistry();
-            SubscribeToAnchorsChanged();
-
-            Logger.Info($"StartScanning — resuming={resuming}, integrationCount={_volumeIntegrator.IntegrationCount}");
-            ScanStarted?.Invoke();
-            if (_modules != null)
-                foreach (var m in _modules) m.OnScanStarted();
         }
 
         /// <summary>
@@ -589,11 +665,18 @@ namespace Genesis.RoomScan
                 foreach (var m in _modules) m.OnScanStopped();
         }
 
-        /// <summary>Toggles between <see cref="StartScanning"/> and <see cref="StopScanning"/>.</summary>
+        /// <summary>
+        /// Toggles between <see cref="StartScanningAsync"/> and <see cref="StopScanning"/>.
+        /// The Start path is fire-and-forget here because this is a debug/dev API
+        /// (typically wired to a debug-menu button) and the small ~56 ms delay
+        /// before integration begins is not worth changing the toggle's signature
+        /// for. Production callers should await <see cref="StartScanningAsync"/>
+        /// directly so they can sequence UI feedback around the start.
+        /// </summary>
         public void ToggleScanning()
         {
             if (IsScanning) StopScanning();
-            else StartScanning();
+            else _ = StartScanningAsync();
         }
 
         /// <summary>True after <see cref="ReleaseScanResources"/> has been called. Cleared when scanning restarts.</summary>
@@ -603,7 +686,7 @@ namespace Genesis.RoomScan
         /// Frees heavy GPU resources (TSDF volumes, Surface Nets buffers, depth textures) to reclaim
         /// ~400-500 MB of GPU memory. Call after scanning + refinement is complete, before entering gameplay.
         /// The refined MeshRenderer stays alive for game-phase rendering.
-        /// Call <see cref="StartScanning"/> to re-allocate everything if a new scan is needed.
+        /// Call <see cref="StartScanningAsync"/> to re-allocate everything if a new scan is needed.
         /// </summary>
         public void ReleaseScanResources()
         {
@@ -643,7 +726,7 @@ namespace Genesis.RoomScan
         /// stalls and potential SynchronizationContext deadlocks on Quest/IL2CPP.
         /// GPU resources are disposed without immediate re-allocation to avoid
         /// Vulkan stalls when the GPU is still referencing the previous frame's buffers.
-        /// Re-initialization happens lazily on the next <see cref="StartScanning"/> or load.
+        /// Re-initialization happens lazily on the next <see cref="StartScanningAsync"/> or load.
         /// </summary>
         public void ClearAllDataAsync(Action onComplete = null)
         {
@@ -1208,6 +1291,7 @@ namespace Genesis.RoomScan
             _refinedMesh.SetNormals(enhanced.Normals);
             _refinedMesh.SetUVs(0, enhanced.UVs);
             _refinedMesh.SetTriangles(enhanced.Indices, 0);
+            _refinedMesh.RecalculateBounds();
 
             EnsureRefinedRenderer();
             _refinedMeshFilter.mesh = _refinedMesh;
@@ -1246,6 +1330,7 @@ namespace Genesis.RoomScan
             _refinedMesh.SetUVs(0, result.UVs);
             _refinedMesh.SetTriangles(result.Indices, 0);
             _refinedMesh.RecalculateTangents();
+            _refinedMesh.RecalculateBounds();
 
             Logger.Info($"Refined mesh applied: " +
                 $"{result.Positions.Length} verts, {result.Indices.Length / 3} tris, " +
@@ -1409,6 +1494,11 @@ namespace Genesis.RoomScan
             _refinedMesh.SetNormals(unwrap.Normals);
             _refinedMesh.SetUVs(0, unwrap.UVs);
             _refinedMesh.SetTriangles(unwrap.Indices, 0);
+            // Without explicit bounds, Unity's frustum culling treats the
+            // mesh as a zero-size point at the local origin and the renderer
+            // pops in/out depending on view direction. SetTriangles does not
+            // recompute bounds when only positions/indices change.
+            _refinedMesh.RecalculateBounds();
             EnsureRefinedRenderer();
             _refinedMeshFilter.mesh = _refinedMesh;
         }
@@ -1802,6 +1892,7 @@ namespace Genesis.RoomScan
                     _refinedMesh.SetNormals(r.Normals);
                     _refinedMesh.SetUVs(0, r.UVs);
                     _refinedMesh.SetTriangles(r.Indices, 0);
+                    _refinedMesh.RecalculateBounds();
                     EnsureRefinedRenderer();
                     _refinedMeshFilter.mesh = _refinedMesh;
                 }

--- a/Runtime/Core/VolumeIntegrator.cs
+++ b/Runtime/Core/VolumeIntegrator.cs
@@ -153,12 +153,31 @@ namespace Genesis.RoomScan
         private void Awake()
         {
             Instance = this;
-            // Create GPU volumes in Awake so RoomScanPersistence.LoadAsync and other
-            // early callers never see Volume == null (Start order is not guaranteed).
-            CreateVolume();
+            // GPU resources allocate lazily on the first scan / save / full-load
+            // path via ReallocateVolumes(). The lightweight LoadRefinedOnlyAsync
+            // path (returning-player and editor-sim) never touches them, so a
+            // pure replay session avoids the ~150 MB TSDF+color RT footprint.
         }
 
         private void Start()
+        {
+            // Intentionally empty — see Awake().
+            //
+            // Historic note: kernel helpers + 3D RTs used to be constructed
+            // here unconditionally. They're now created on demand inside
+            // ReallocateVolumes(), which is called by:
+            //   * RoomScanner.StartScanning() (every scan begin)
+            //   * RoomScanPersistence.SaveToNewPackageAsync (defensive)
+            //   * RoomScanPersistence.LoadPackageAsync (full TSDF reload)
+        }
+
+        /// <summary>
+        /// Build all compute-kernel helpers and bind them to the current
+        /// <see cref="_volume"/> / <see cref="_colorVolume"/>. Idempotent —
+        /// the first <see cref="ReallocateVolumes"/> call constructs them;
+        /// subsequent allocations only need <see cref="RebindKernelTextures"/>.
+        /// </summary>
+        private void InitKernels()
         {
             _clearKernel = new ComputeKernelHelper(compute, "Clear");
             _clearKernel.Set(VolumeRWID, _volume);
@@ -187,12 +206,6 @@ namespace Genesis.RoomScan
             _dummyCamTex = new Texture2D(1, 1, TextureFormat.RGBA32, false);
             _dummyCamTex.SetPixel(0, 0, Color.black);
             _dummyCamTex.Apply(false, true);
-
-            SetShaderConstants();
-            Clear();
-
-            if (DepthCapture.Instance != null)
-                DepthCapture.Instance.SetVoxelParams(voxelDistance, voxelSize);
         }
 
         private void OnDestroy()
@@ -224,16 +237,44 @@ namespace Genesis.RoomScan
         public bool VolumesReleased => _volume == null;
 
         /// <summary>
-        /// Re-creates TSDF + color volumes after a prior <see cref="ReleaseVolumes"/> call.
+        /// Allocate (or re-allocate) TSDF + color volumes and bring kernels +
+        /// shader constants up to date. Idempotent — early-returns if volumes
+        /// already exist. Handles three scenarios:
+        /// <list type="bullet">
+        ///   <item><description><b>First-ever scan</b>: builds compute kernels
+        ///   from scratch (deferred from the old eager <c>Awake</c>/<c>Start</c>
+        ///   path), allocates RTs, sets globals.</description></item>
+        ///   <item><description><b>Resume after <see cref="ReleaseVolumes"/></b>:
+        ///   re-allocates RTs and rebinds existing kernels via
+        ///   <see cref="RebindKernelTextures"/>.</description></item>
+        ///   <item><description><b>Already allocated</b>: no-op.</description></item>
+        /// </list>
+        /// Called by <see cref="RoomScanner.StartScanningAsync"/> and the heavy
+        /// <c>RoomScanPersistence</c> save/full-load paths. The lightweight
+        /// <c>LoadRefinedOnlyAsync</c> path intentionally skips this.
         /// </summary>
         public void ReallocateVolumes()
         {
             if (_volume != null) return;
+
+            // ComputeKernelHelper is a struct — use its readonly Shader
+            // backing field as the "never initialized" sentinel.
+            bool firstAlloc = (_clearKernel.Shader == null);
+
             CreateVolume();
+
+            if (firstAlloc) InitKernels();
+            else            RebindKernelTextures();
+
             SetShaderConstants();
             Clear();
-            RebindKernelTextures();
-            Logger.Info("VolumeIntegrator: GPU volumes re-allocated");
+
+            if (DepthCapture.Instance != null)
+                DepthCapture.Instance.SetVoxelParams(voxelDistance, voxelSize);
+
+            Logger.Info(firstAlloc
+                ? "VolumeIntegrator: GPU resources allocated lazily on first scan/save/full-load."
+                : "VolumeIntegrator: GPU volumes re-allocated after release.");
         }
 
         private void RebindKernelTextures()
@@ -326,10 +367,13 @@ namespace Genesis.RoomScan
         }
 
         /// <summary>
-        /// Zeros the TSDF and color volumes on the GPU.
+        /// Zeros the TSDF and color volumes on the GPU. No-op if volumes
+        /// haven't been allocated yet (lazy alloc — see
+        /// <see cref="ReallocateVolumes"/>).
         /// </summary>
         public void Clear()
         {
+            if (_volume == null || _clearKernel.Shader == null) return;
             _clearKernel.Set(VolumeRWID, _volume);
             _clearKernel.Set(ColorVolumeRWID, _colorVolume);
             _clearKernel.DispatchFit(_volume);
@@ -415,6 +459,11 @@ namespace Genesis.RoomScan
         public void FreezeInView(Vector3 camPos, Quaternion camRot,
             Vector2 focalLen, Vector2 principalPt, Vector2 sensorRes, Vector2 currentRes)
         {
+            if (_volume == null || _freezeKernel.Shader == null)
+            {
+                Logger.Warning("FreezeInView called before GPU resources allocated; ignored.");
+                return;
+            }
             SetFrustumCameraUniforms(_freezeKernel, camPos, camRot,
                 focalLen, principalPt, sensorRes, currentRes);
             _freezeKernel.Set(VolumeRWID, _volume);
@@ -428,6 +477,11 @@ namespace Genesis.RoomScan
         public void UnfreezeInView(Vector3 camPos, Quaternion camRot,
             Vector2 focalLen, Vector2 principalPt, Vector2 sensorRes, Vector2 currentRes)
         {
+            if (_volume == null || _unfreezeKernel.Shader == null)
+            {
+                Logger.Warning("UnfreezeInView called before GPU resources allocated; ignored.");
+                return;
+            }
             SetFrustumCameraUniforms(_unfreezeKernel, camPos, camRot,
                 focalLen, principalPt, sensorRes, currentRes);
             _unfreezeKernel.Set(VolumeRWID, _volume);
@@ -552,6 +606,11 @@ namespace Genesis.RoomScan
         {
             var dc = DepthCapture.Instance;
             if (dc == null || !DepthCapture.DepthAvailable || dc.DepthTex == null) return;
+            // Defensive: with lazy GPU alloc a stray Integrate() before
+            // ReallocateVolumes can land here. RoomScanner.StartScanning()
+            // always calls ReallocateVolumes first, so this is just a
+            // safety net.
+            if (_volume == null || _integrateKernel.Shader == null) return;
             if (!_frustumReady) SetupFrustumVolume();
             if (!_frustumReady) return;
 

--- a/Runtime/Utils/RoomScanSession.cs
+++ b/Runtime/Utils/RoomScanSession.cs
@@ -54,11 +54,25 @@ namespace Genesis.RoomScan
                 ProgressUpdated?.Invoke(_scanner.CurrentProgress);
         }
 
-        /// <summary>Begins a new scan session. The room mesh builds in real-time as the user looks around.</summary>
-        public void StartScan()
+        /// <summary>
+        /// Begins a new scan session. The room mesh builds in real-time as
+        /// the user looks around. Async because <see cref="RoomScanner.StartScanningAsync"/>
+        /// stages the heavy GPU bring-up across a few frames before
+        /// enabling the passthrough camera (otherwise the PCA / MRUK
+        /// handshake races our compute dispatches and the compositor
+        /// freezes — see that method's docs for the full story). Total
+        /// wall-clock from await to first integrated frame is ~56 ms,
+        /// imperceptible to the user but worth awaiting so callers can
+        /// sequence UI feedback ("Scanning…") right after.
+        /// </summary>
+        public Task StartScanAsync()
         {
-            if (_scanner == null) { Logger.Error("RoomScanSession: RoomScanner not found"); return; }
-            _scanner.StartScanning();
+            if (_scanner == null)
+            {
+                Logger.Error("RoomScanSession: RoomScanner not found");
+                return Task.CompletedTask;
+            }
+            return _scanner.StartScanningAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
Promotes the squashed merge of #16 (a76f42a) from develop to main.

See #16 for the full description and test plan.

Made with [Cursor](https://cursor.com)